### PR TITLE
Polishing

### DIFF
--- a/context-propagation-api/src/main/java/io/micrometer/contextpropagation/ContextScope.java
+++ b/context-propagation-api/src/main/java/io/micrometer/contextpropagation/ContextScope.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.contextpropagation;
+
+
+/**
+ * Demarcates the scope of restored ThreadLocal values.
+ */
+public interface ContextScope extends AutoCloseable {
+
+    @Override
+    void close();
+
+}

--- a/context-propagation-api/src/main/java/io/micrometer/contextpropagation/DefaultContextContainer.java
+++ b/context-propagation-api/src/main/java/io/micrometer/contextpropagation/DefaultContextContainer.java
@@ -121,7 +121,7 @@ public class DefaultContextContainer implements ContextContainer {
     }
 
     @Override
-    public Scope restoreThreadLocalValues() {
+    public ContextScope restoreThreadLocalValues() {
         List<ThreadLocalAccessor> accessors = new ArrayList<>();
         for (ThreadLocalAccessor accessor : this.threadLocalAccessors) {
             if (this.predicates.stream().allMatch(predicate -> predicate.test(accessor.getNamespace()))) {
@@ -140,35 +140,6 @@ public class DefaultContextContainer implements ContextContainer {
     public <T> T saveTo(T context) {
         ContextContainerAdapter adapter = ContextContainerAdapterLoader.getAdapterToWrite(context);
         return (T) adapter.save(this, context);
-    }
-
-    /**
-     * Restores the thread local values and runs the given action. No exception
-     * catching takes place.
-     *
-     * @param action action to run
-     */
-    @Override
-    @SuppressWarnings("unused")
-    public void tryScoped(Runnable action) {
-        try (Scope scope = restoreThreadLocalValues()) {
-            action.run();
-        }
-    }
-
-    /**
-     * Restores the thread local values and runs the given action. No exception
-     * catching takes place.
-     *
-     * @param action action to run
-     * @return result of the action
-     */
-    @Override
-    @SuppressWarnings("unused")
-    public <T> T tryScoped(Supplier<T> action) {
-        try (Scope scope = restoreThreadLocalValues()) {
-            return action.get();
-        }
     }
 
     @Override

--- a/context-propagation-api/src/main/java/io/micrometer/contextpropagation/WrappedExecutorService.java
+++ b/context-propagation-api/src/main/java/io/micrometer/contextpropagation/WrappedExecutorService.java
@@ -62,41 +62,41 @@ class WrappedExecutorService implements ExecutorService {
 
     @Override
     public <T> Future<T> submit(Callable<T> task) {
-        return executorService.submit(this.contextContainer.wrap(task));
+        return executorService.submit(this.contextContainer.instrument(task));
     }
 
     @Override
     public <T> Future<T> submit(Runnable task, T result) {
-        return executorService.submit(this.contextContainer.wrap(task), result);
+        return executorService.submit(this.contextContainer.instrument(task), result);
     }
 
     @Override
     public Future<?> submit(Runnable task) {
-        return executorService.submit(this.contextContainer.wrap(task));
+        return executorService.submit(this.contextContainer.instrument(task));
     }
 
     @Override
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
-        return executorService.invokeAll(tasks.stream().map(this.contextContainer::wrap).collect(Collectors.toList()));
+        return executorService.invokeAll(tasks.stream().map(this.contextContainer::instrument).collect(Collectors.toList()));
     }
 
     @Override
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
-        return executorService.invokeAll(tasks.stream().map(this.contextContainer::wrap).collect(Collectors.toList()), timeout, unit);
+        return executorService.invokeAll(tasks.stream().map(this.contextContainer::instrument).collect(Collectors.toList()), timeout, unit);
     }
 
     @Override
     public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
-        return executorService.invokeAny(tasks.stream().map(this.contextContainer::wrap).collect(Collectors.toList()));
+        return executorService.invokeAny(tasks.stream().map(this.contextContainer::instrument).collect(Collectors.toList()));
     }
 
     @Override
     public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-        return executorService.invokeAny(tasks.stream().map(this.contextContainer::wrap).collect(Collectors.toList()), timeout, unit);
+        return executorService.invokeAny(tasks.stream().map(this.contextContainer::instrument).collect(Collectors.toList()), timeout, unit);
     }
 
     @Override
     public void execute(Runnable command) {
-        executorService.execute(this.contextContainer.wrap(command));
+        executorService.execute(this.contextContainer.instrument(command));
     }
 }

--- a/context-propagation-api/src/test/java/io/micrometer/contextpropagation/InstrumentationTests.java
+++ b/context-propagation-api/src/test/java/io/micrometer/contextpropagation/InstrumentationTests.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2019 VMware, Inc.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -49,7 +49,7 @@ class InstrumentationTests {
         runInNewThread(runnable);
         then(valueInNewThread.get()).as("By default thread local information should not be propagated").isNull();
 
-        runInNewThread(container.wrap(runnable));
+        runInNewThread(container.instrument(runnable));
 
         then(valueInNewThread.get()).as("With context container the thread local information should be propagated").isEqualTo("hello");
     }
@@ -65,7 +65,7 @@ class InstrumentationTests {
         runInNewThread(callable);
         then(valueInNewThread.get()).as("By default thread local information should not be propagated").isNull();
 
-        runInNewThread(container.wrap(callable));
+        runInNewThread(container.instrument(callable));
 
         then(valueInNewThread.get()).as("With context container the thread local information should be propagated").isEqualTo("hello");
     }
@@ -78,7 +78,7 @@ class InstrumentationTests {
         runInNewThread(executor, valueInNewThread);
         then(valueInNewThread.get()).as("By default thread local information should not be propagated").isNull();
 
-        runInNewThread(container.wrap(executor), valueInNewThread);
+        runInNewThread(container.instrument(executor), valueInNewThread);
 
         then(valueInNewThread.get()).as("With context container the thread local information should be propagated").isEqualTo("hello");
     }
@@ -91,7 +91,7 @@ class InstrumentationTests {
             AtomicReference<String> valueInNewThread = new AtomicReference<>();
             runInNewThread(executor, valueInNewThread, atomic -> then(atomic.get()).as("By default thread local information should not be propagated").isNull());
 
-            runInNewThread(container.wrap(executor), valueInNewThread, atomic -> then(atomic.get()).as("With context container the thread local information should be propagated").isEqualTo("hello"));
+            runInNewThread(container.instrument(executor), valueInNewThread, atomic -> then(atomic.get()).as("With context container the thread local information should be propagated").isEqualTo("hello"));
         } finally {
             executor.shutdown();
         }

--- a/context-propagation-api/src/test/java/io/micrometer/contextpropagation/SimpleThreadLocalAccessorTests.java
+++ b/context-propagation-api/src/test/java/io/micrometer/contextpropagation/SimpleThreadLocalAccessorTests.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2019 VMware, Inc.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,7 +36,7 @@ class SimpleThreadLocalAccessorTests {
         ObservationThreadLocalHolder.holder.remove();
         then(ObservationThreadLocalHolder.holder.get()).isNull();
 
-        try (ContextContainer.Scope scope = container.restoreThreadLocalValues()) {
+        try (ContextScope scope = container.restoreThreadLocalValues()) {
             then(ObservationThreadLocalHolder.holder.get()).isEqualTo("hello");
         }
 
@@ -52,7 +52,7 @@ class SimpleThreadLocalAccessorTests {
         ObservationThreadLocalHolder.holder.remove();
         then(ObservationThreadLocalHolder.holder.get()).isNull();
 
-        try (ContextContainer.Scope scope = container.restoreThreadLocalValues()) {
+        try (ContextScope scope = container.restoreThreadLocalValues()) {
             then(ObservationThreadLocalHolder.holder.get()).isNull();
         }
 
@@ -69,7 +69,7 @@ class SimpleThreadLocalAccessorTests {
         ObservationThreadLocalHolder.holder.remove();
         then(ObservationThreadLocalHolder.holder.get()).isNull();
 
-        try (ContextContainer.Scope scope = container.restoreThreadLocalValues()) {
+        try (ContextScope scope = container.restoreThreadLocalValues()) {
             then(ObservationThreadLocalHolder.holder.get()).isNull();
         }
 


### PR DESCRIPTION
- Make `Scoped` a top-level type and rename to `ContextScope`.
- Rename `wrap` methods to `instrument`.
- Drop `tryScoped` methods. They are trivial and `ContextContainer` should focus on instrumentation and propagation more so than on invocation. We can reintroduce them later, but they seem too trivial and non-essential for now.