### PR TITLE
Shorten `contextpropagation` package name to just `context`

### DIFF
--- a/context-propagation-api/src/main/java/io/micrometer/context/ContextAccessor.java
+++ b/context-propagation-api/src/main/java/io/micrometer/context/ContextAccessor.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.contextpropagation;
+package io.micrometer.context;
 
 /**
  * Contract to assist with extracting and restoring context values to

--- a/context-propagation-api/src/main/java/io/micrometer/context/ContextContainer.java
+++ b/context-propagation-api/src/main/java/io/micrometer/context/ContextContainer.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.contextpropagation;
+package io.micrometer.context;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;

--- a/context-propagation-api/src/main/java/io/micrometer/context/ContextContainerAdapter.java
+++ b/context-propagation-api/src/main/java/io/micrometer/context/ContextContainerAdapter.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.contextpropagation;
+package io.micrometer.context;
 
 import java.util.ServiceLoader;
 

--- a/context-propagation-api/src/main/java/io/micrometer/context/ContextContainerAdapterLoader.java
+++ b/context-propagation-api/src/main/java/io/micrometer/context/ContextContainerAdapterLoader.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.contextpropagation;
+package io.micrometer.context;
 
 import java.util.Map;
 import java.util.ServiceLoader;

--- a/context-propagation-api/src/main/java/io/micrometer/context/ContextScope.java
+++ b/context-propagation-api/src/main/java/io/micrometer/context/ContextScope.java
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.contextpropagation;
+package io.micrometer.context;
+
 
 /**
- * Storage for a {@link Namespace}.
- *
- * @author Marcin Grzejszczak
- * @since 1.0.0
+ * Demarcates the scope of restored ThreadLocal values.
  */
-public interface Store {
+public interface ContextScope extends AutoCloseable {
+
+    @Override
+    void close();
 
 }

--- a/context-propagation-api/src/main/java/io/micrometer/context/DefaultContextContainer.java
+++ b/context-propagation-api/src/main/java/io/micrometer/context/DefaultContextContainer.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.contextpropagation;
+package io.micrometer.context;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/context-propagation-api/src/main/java/io/micrometer/context/Namespace.java
+++ b/context-propagation-api/src/main/java/io/micrometer/context/Namespace.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.contextpropagation;
+package io.micrometer.context;
 
 /**
  * A {@code Namespace} is used to provide a <em>scope</em> for data saved by

--- a/context-propagation-api/src/main/java/io/micrometer/context/NamespaceAccessor.java
+++ b/context-propagation-api/src/main/java/io/micrometer/context/NamespaceAccessor.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.contextpropagation;
+package io.micrometer.context;
 
 import java.util.function.Predicate;
 

--- a/context-propagation-api/src/main/java/io/micrometer/context/SimpleNamespace.java
+++ b/context-propagation-api/src/main/java/io/micrometer/context/SimpleNamespace.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.contextpropagation;
+package io.micrometer.context;
 
 import java.util.Objects;
 

--- a/context-propagation-api/src/main/java/io/micrometer/context/Store.java
+++ b/context-propagation-api/src/main/java/io/micrometer/context/Store.java
@@ -13,15 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.contextpropagation;
-
+package io.micrometer.context;
 
 /**
- * Demarcates the scope of restored ThreadLocal values.
+ * Storage for a {@link Namespace}.
+ *
+ * @author Marcin Grzejszczak
+ * @since 1.0.0
  */
-public interface ContextScope extends AutoCloseable {
-
-    @Override
-    void close();
+public interface Store {
 
 }

--- a/context-propagation-api/src/main/java/io/micrometer/context/ThreadLocalAccessor.java
+++ b/context-propagation-api/src/main/java/io/micrometer/context/ThreadLocalAccessor.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.contextpropagation;
+package io.micrometer.context;
 
 import java.util.ServiceLoader;
 import java.util.function.Predicate;

--- a/context-propagation-api/src/main/java/io/micrometer/context/WrappedExecutorService.java
+++ b/context-propagation-api/src/main/java/io/micrometer/context/WrappedExecutorService.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.contextpropagation;
+package io.micrometer.context;
 
 import java.util.Collection;
 import java.util.List;

--- a/context-propagation-api/src/test/java/io/micrometer/context/InstrumentationTests.java
+++ b/context-propagation-api/src/test/java/io/micrometer/context/InstrumentationTests.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.contextpropagation;
+package io.micrometer.context;
 
 import java.util.Collections;
 import java.util.concurrent.Callable;

--- a/context-propagation-api/src/test/java/io/micrometer/context/ObservationThreadLocalAccessor.java
+++ b/context-propagation-api/src/test/java/io/micrometer/context/ObservationThreadLocalAccessor.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.contextpropagation;
+package io.micrometer.context;
 
 public class ObservationThreadLocalAccessor implements ThreadLocalAccessor {
 

--- a/context-propagation-api/src/test/java/io/micrometer/context/ObservationThreadLocalHolder.java
+++ b/context-propagation-api/src/test/java/io/micrometer/context/ObservationThreadLocalHolder.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.contextpropagation;
+package io.micrometer.context;
 
 public class ObservationThreadLocalHolder {
     static final ThreadLocal<String> holder = new ThreadLocal<>();

--- a/context-propagation-api/src/test/java/io/micrometer/context/SimpleThreadLocalAccessorTests.java
+++ b/context-propagation-api/src/test/java/io/micrometer/context/SimpleThreadLocalAccessorTests.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.contextpropagation;
+package io.micrometer.context;
 
 import java.util.Collections;
 


### PR DESCRIPTION
A better balance between retaining enough meaning but avoiding a double word.