### PR TITLE
Support Serviceloader in ContextRegistry

### DIFF
--- a/context-propagation-api/src/main/java/io/micrometer/context/DefaultContextSnapshot.java
+++ b/context-propagation-api/src/main/java/io/micrometer/context/DefaultContextSnapshot.java
@@ -97,7 +97,7 @@ final class DefaultContextSnapshot extends HashMap<Object, Object> implements Co
 
     @Override
     public String toString() {
-        return "DefaultContextSnapshot" + this;
+        return "DefaultContextSnapshot" + super.toString();
     }
 
 

--- a/context-propagation-api/src/main/resources/META-INF/services/io.micrometer.context.ContextAccessor
+++ b/context-propagation-api/src/main/resources/META-INF/services/io.micrometer.context.ContextAccessor
@@ -1,0 +1,1 @@
+io.micrometer.context.ReactorContextAccessor

--- a/context-propagation-api/src/test/java/io/micrometer/context/ContextRegistryTests.java
+++ b/context-propagation-api/src/test/java/io/micrometer/context/ContextRegistryTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.context;
+
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link ContextRegistry}.
+ *
+ * @author Rossen Stoyanchev
+ */
+public class ContextRegistryTests {
+
+    private final ContextRegistry registry = new ContextRegistry();
+
+
+    @Test
+    void should_remove_existing_context_accessors_of_same_type() {
+        TestContextAccessor contextAccessor1 = new TestContextAccessor();
+        TestContextAccessor contextAccessor2 = new TestContextAccessor();
+
+        this.registry.registerContextAccessor(contextAccessor1);
+        assertThat(this.registry.getContextAccessors()).containsExactly(contextAccessor1);
+
+        this.registry.registerContextAccessor(contextAccessor2);
+        assertThat(this.registry.getContextAccessors()).containsExactly(contextAccessor2);
+    }
+
+    @Test
+    void should_remove_existing_thread_local_accessors_for_same_key() {
+        TestThreadLocalAccessor accessor1 = new TestThreadLocalAccessor("foo", new ThreadLocal<>());
+        TestThreadLocalAccessor accessor2 = new TestThreadLocalAccessor("foo", new ThreadLocal<>());
+        TestThreadLocalAccessor accessor3 = new TestThreadLocalAccessor("bar", new ThreadLocal<>());
+
+        this.registry.registerThreadLocalAccessor(accessor1);
+        assertThat(this.registry.getThreadLocalAccessors()).containsExactly(accessor1);
+
+        this.registry.registerThreadLocalAccessor(accessor2);
+        assertThat(this.registry.getThreadLocalAccessors()).containsExactly(accessor2);
+
+        this.registry.registerThreadLocalAccessor(accessor3);
+        assertThat(this.registry.getThreadLocalAccessors()).containsExactly(accessor2, accessor3);
+    }
+
+}

--- a/context-propagation-api/src/test/java/io/micrometer/context/DefaultContextSnapshotTests.java
+++ b/context-propagation-api/src/test/java/io/micrometer/context/DefaultContextSnapshotTests.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.then;
 
 /**
@@ -150,5 +151,23 @@ public class DefaultContextSnapshotTests {
         then(barThreadLocal.get()).isNull();
     }
 
-}
+    @Test
+    void toString_should_include_values() {
+        ThreadLocal<String> fooThreadLocal = new ThreadLocal<>();
+        ThreadLocal<String> barThreadLocal = new ThreadLocal<>();
 
+        this.registry
+                .registerThreadLocalAccessor(new TestThreadLocalAccessor("foo", fooThreadLocal))
+                .registerThreadLocalAccessor(new TestThreadLocalAccessor("bar", barThreadLocal));
+
+        fooThreadLocal.set("fooValue");
+        barThreadLocal.set("barValue");
+
+        assertThat(this.snapshotBuilder.build().toString())
+                .isEqualTo("DefaultContextSnapshot{bar=barValue, foo=fooValue}");
+
+        fooThreadLocal.remove();
+        barThreadLocal.remove();
+    }
+
+}

--- a/context-propagation-api/src/test/java/io/micrometer/context/DefaultContextSnapshotTests.java
+++ b/context-propagation-api/src/test/java/io/micrometer/context/DefaultContextSnapshotTests.java
@@ -151,3 +151,4 @@ public class DefaultContextSnapshotTests {
     }
 
 }
+

--- a/context-propagation-api/src/test/java/io/micrometer/context/TestContextAccessor.java
+++ b/context-propagation-api/src/test/java/io/micrometer/context/TestContextAccessor.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.context;
+
+import java.util.Map;
+import java.util.function.Predicate;
+
+/**
+ * ThreadLocalAccessor for testing purposes with a given key and
+ * {@link ThreadLocal} instance.
+ *
+ * @author Rossen Stoyanchev
+ */
+class TestContextAccessor implements ContextAccessor<Map<?, ?>, Map<?, ?>> {
+
+    @Override
+    public boolean canReadFrom(Class<?> contextType) {
+        return Map.class.isAssignableFrom(contextType);
+    }
+
+    @Override
+    public void readValues(Map<?, ?> sourceContext, Predicate<Object> keyPredicate, Map<Object, Object> readValues) {
+        readValues.putAll(sourceContext);
+    }
+
+    @Override
+    public boolean canWriteTo(Class<?> contextType) {
+        return Map.class.isAssignableFrom(contextType);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Map<?, ?> writeValues(Map<Object, Object> valuesToWrite, Map<?, ?> targetContext) {
+        ((Map<Object, Object>) targetContext).putAll(valuesToWrite);
+        return targetContext;
+    }
+
+}


### PR DESCRIPTION
This pull request adds support for `ContextAccessor` and `ThreadLocalAccessor` registrations through the `ServiceLoader` mechanism. A `ReactorContextAccessor` is declared temporarily in this repo.

Also includes a fix for a bug with recursion in the `toString` of `DefaultContextSnapshot`.