### PR TITLE
Rename methods in ContextSnapshot

### DIFF
--- a/context-propagation-api/src/main/java/io/micrometer/context/ContextExecutorService.java
+++ b/context-propagation-api/src/main/java/io/micrometer/context/ContextExecutorService.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
  * @author Rossen Stoyanchev
  * @since 1.0.0
  */
-final class InstrumentedExecutorService implements ExecutorService {
+final class ContextExecutorService implements ExecutorService {
 
     private final ContextSnapshot contextSnapshot;
 
@@ -46,7 +46,7 @@ final class InstrumentedExecutorService implements ExecutorService {
      * @param executorService the {@code ExecutorService} to delegate to
      * @param contextSnapshot the {@code ContextSnapshot} with values to propagate
      */
-    InstrumentedExecutorService(ExecutorService executorService, ContextSnapshot contextSnapshot) {
+    ContextExecutorService(ExecutorService executorService, ContextSnapshot contextSnapshot) {
         this.contextSnapshot = contextSnapshot;
         this.executorService = executorService;
     }
@@ -79,17 +79,17 @@ final class InstrumentedExecutorService implements ExecutorService {
 
     @Override
     public <T> Future<T> submit(Callable<T> task) {
-        return this.executorService.submit(this.contextSnapshot.instrumentCallable(task));
+        return this.executorService.submit(this.contextSnapshot.wrap(task));
     }
 
     @Override
     public <T> Future<T> submit(Runnable task, T result) {
-        return this.executorService.submit(this.contextSnapshot.instrumentRunnable(task), result);
+        return this.executorService.submit(this.contextSnapshot.wrap(task), result);
     }
 
     @Override
     public Future<?> submit(Runnable task) {
-        return this.executorService.submit(this.contextSnapshot.instrumentRunnable(task));
+        return this.executorService.submit(this.contextSnapshot.wrap(task));
     }
 
     @Override
@@ -97,7 +97,7 @@ final class InstrumentedExecutorService implements ExecutorService {
             throws InterruptedException {
 
         List<Callable<T>> instrumentedTasks = tasks.stream()
-                .map(this.contextSnapshot::instrumentCallable)
+                .map(this.contextSnapshot::wrap)
                 .collect(Collectors.toList());
 
         return this.executorService.invokeAll(instrumentedTasks);
@@ -109,7 +109,7 @@ final class InstrumentedExecutorService implements ExecutorService {
             throws InterruptedException {
 
         List<Callable<T>> instrumentedTasks = tasks.stream()
-                .map(this.contextSnapshot::instrumentCallable)
+                .map(this.contextSnapshot::wrap)
                 .collect(Collectors.toList());
 
         return this.executorService.invokeAll(instrumentedTasks, timeout, unit);
@@ -120,7 +120,7 @@ final class InstrumentedExecutorService implements ExecutorService {
             throws InterruptedException, ExecutionException {
 
         List<Callable<T>> instrumentedTasks = tasks.stream()
-                .map(this.contextSnapshot::instrumentCallable)
+                .map(this.contextSnapshot::wrap)
                 .collect(Collectors.toList());
 
         return this.executorService.invokeAny(instrumentedTasks);
@@ -132,7 +132,7 @@ final class InstrumentedExecutorService implements ExecutorService {
             throws InterruptedException, ExecutionException, TimeoutException {
 
         List<Callable<T>> instrumentedTasks = tasks.stream()
-                .map(this.contextSnapshot::instrumentCallable)
+                .map(this.contextSnapshot::wrap)
                 .collect(Collectors.toList());
 
         return this.executorService.invokeAny(instrumentedTasks, timeout, unit);
@@ -140,7 +140,7 @@ final class InstrumentedExecutorService implements ExecutorService {
 
     @Override
     public void execute(Runnable command) {
-        this.executorService.execute(this.contextSnapshot.instrumentRunnable(command));
+        this.executorService.execute(this.contextSnapshot.wrap(command));
     }
 
 }

--- a/context-propagation-api/src/test/java/io/micrometer/context/ContextWrappingTests.java
+++ b/context-propagation-api/src/test/java/io/micrometer/context/ContextWrappingTests.java
@@ -32,9 +32,9 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.BDDAssertions.then;
 
 /**
- * 
+ * Unit tests for the {@code "wrap"} methods in {@link ContextSnapshot}.
  */
-class InstrumentationTests {
+class ContextWrappingTests {
 
     private final ContextRegistry registry = new ContextRegistry()
             .registerThreadLocalAccessor(new ObservationThreadLocalAccessor());
@@ -55,7 +55,7 @@ class InstrumentationTests {
                 .as("By default thread local information should not be propagated")
                 .isNull();
 
-        runInNewThread(ContextSnapshot.capture(this.registry, key -> true).instrumentRunnable(runnable));
+        runInNewThread(ContextSnapshot.captureUsing(this.registry, key -> true).wrap(runnable));
 
         then(valueInNewThread.get())
                 .as("With context container the thread local information should be propagated")
@@ -75,7 +75,7 @@ class InstrumentationTests {
                 .as("By default thread local information should not be propagated")
                 .isNull();
 
-        runInNewThread(ContextSnapshot.capture(this.registry, key -> true).instrumentCallable(callable));
+        runInNewThread(ContextSnapshot.captureUsing(this.registry, key -> true).wrap(callable));
 
         then(valueInNewThread.get())
                 .as("With context container the thread local information should be propagated")
@@ -93,7 +93,7 @@ class InstrumentationTests {
                 .isNull();
 
         runInNewThread(
-                ContextSnapshot.capture(this.registry, key -> true).instrumentExecutor(executor),
+                ContextSnapshot.captureUsing(this.registry, key -> true).wrapExecutor(executor),
                 valueInNewThread);
 
         then(valueInNewThread.get())
@@ -113,7 +113,7 @@ class InstrumentationTests {
                             .isNull());
 
             runInNewThread(
-                    ContextSnapshot.capture(this.registry, key -> true).instrumentExecutorService(executorService),
+                    ContextSnapshot.captureUsing(this.registry, key -> true).wrapExecutorService(executorService),
                     valueInNewThread,
                     atomic -> then(atomic.get())
                             .as("With context container the thread local information should be propagated")

--- a/context-propagation-api/src/test/java/io/micrometer/context/DefaultContextSnapshotTests.java
+++ b/context-propagation-api/src/test/java/io/micrometer/context/DefaultContextSnapshotTests.java
@@ -38,7 +38,7 @@ public class DefaultContextSnapshotTests {
         then(ObservationThreadLocalHolder.getValue()).isNull();
         ObservationThreadLocalHolder.setValue("hello");
 
-        ContextSnapshot snapshot = ContextSnapshot.capture(this.registry, key -> true);
+        ContextSnapshot snapshot = ContextSnapshot.captureUsing(this.registry, key -> true);
 
         ObservationThreadLocalHolder.reset();
         then(ObservationThreadLocalHolder.getValue()).isNull();
@@ -55,7 +55,7 @@ public class DefaultContextSnapshotTests {
         this.registry.registerThreadLocalAccessor(new ObservationThreadLocalAccessor());
 
         ObservationThreadLocalHolder.setValue("hello");
-        ContextSnapshot snapshot = ContextSnapshot.capture(this.registry, key -> true);
+        ContextSnapshot snapshot = ContextSnapshot.captureUsing(this.registry, key -> true);
 
         ObservationThreadLocalHolder.setValue("hola");
         try {
@@ -75,7 +75,7 @@ public class DefaultContextSnapshotTests {
 
         then(ObservationThreadLocalHolder.getValue()).isNull();
 
-        ContextSnapshot snapshot = ContextSnapshot.capture(this.registry, key -> true);
+        ContextSnapshot snapshot = ContextSnapshot.captureUsing(this.registry, key -> true);
 
         ObservationThreadLocalHolder.reset();
         then(ObservationThreadLocalHolder.getValue()).isNull();
@@ -99,7 +99,7 @@ public class DefaultContextSnapshotTests {
         fooThreadLocal.set("fooValue");
         barThreadLocal.set("barValue");
 
-        ContextSnapshot snapshot = ContextSnapshot.capture(this.registry, key -> key.equals("foo"));
+        ContextSnapshot snapshot = ContextSnapshot.captureUsing(this.registry, key -> key.equals("foo"));
 
         fooThreadLocal.remove();
         barThreadLocal.remove();
@@ -125,7 +125,7 @@ public class DefaultContextSnapshotTests {
         fooThreadLocal.set("fooValue");
         barThreadLocal.set("barValue");
 
-        ContextSnapshot snapshot = ContextSnapshot.capture(this.registry, key -> true);
+        ContextSnapshot snapshot = ContextSnapshot.captureUsing(this.registry, key -> true);
 
         fooThreadLocal.remove();
         barThreadLocal.remove();
@@ -156,7 +156,7 @@ public class DefaultContextSnapshotTests {
         fooThreadLocal.set("fooValue");
         barThreadLocal.set("barValue");
 
-        assertThat(ContextSnapshot.capture(this.registry, key -> true).toString())
+        assertThat(ContextSnapshot.captureUsing(this.registry, key -> true).toString())
                 .isEqualTo("DefaultContextSnapshot{bar=barValue, foo=fooValue}");
 
         fooThreadLocal.remove();


### PR DESCRIPTION
This commit shortens the main method for capturing, which could be used in applications and its length does matter. The additional two capture methods, with extra options, and which cannot be overloaded methods due to ambiguity with the Object vararg, become slightly longer but only by a little, and those should be much less common to use in any case.

The `instrument*` methods are also renamed to `wrap` for similar reasons as well as due to being potentially interpreted with a different meaning (JVM instrumentation).