### PR TITLE
Add method to capture from a single context object

### DIFF
--- a/context-propagation/src/main/java/io/micrometer/context/ContextSnapshot.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ContextSnapshot.java
@@ -167,6 +167,15 @@ public interface ContextSnapshot {
     }
 
     /**
+     * Create a {@link ContextSnapshot} by reading values from the given context object.
+     * @param context the context to read values from
+     * @return the created {@link ContextSnapshot}
+     */
+    static ContextSnapshot captureFrom(Object context) {
+        return DefaultContextSnapshot.captureFromContext(ContextRegistry.getInstance(), key -> true, context, null);
+    }
+
+    /**
      * Read the values specified by from the given source context, and if found,
      * use them to set {@link ThreadLocal} values. Essentially, a shortcut that
      * bypasses the need to create of {@link ContextSnapshot} first via


### PR DESCRIPTION
There is a common case to create a snapshot from a single context object, e.g. using Reactor `Context` to restore `ThreadLocal` values within a Reactor chain. In that case it is only necessary to read from the Reactor context, and there is no need to check or even attempt to capture `ThreadLocal` values. The method is intended for this scenario.