### PR TITLE
Throws IllegalArgumentException when no keys are passed to ContextSnapshot

### DIFF
--- a/context-propagation/src/main/java/io/micrometer/context/ContextSnapshot.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ContextSnapshot.java
@@ -189,7 +189,7 @@ public interface ContextSnapshot {
      * to create of {@link ContextSnapshot} first via {@link #captureAll(Object...)},
      * followed by {@link #setThreadLocals()}.
      * @param sourceContext the source context to read values from
-     * @param keys the keys of the values to read
+     * @param keys the keys of the values to read (at least one key must be passed)
      * @return an object that can be used to reset {@link ThreadLocal} values at the end
      * of the context scope, either removing them or restoring their previous values, if
      * any.
@@ -203,7 +203,7 @@ public interface ContextSnapshot {
      * {@link ContextRegistry} instead of the global instance.
      * @param sourceContext the source context to read values from
      * @param contextRegistry the registry with the accessors to use
-     * @param keys the keys of the values to read
+     * @param keys the keys of the values to read (at least one key must be passed)
      * @return an object that can be used to reset {@link ThreadLocal} values at the end
      * of the context scope, either removing them or restoring their previous values, if
      * any.

--- a/context-propagation/src/main/java/io/micrometer/context/DefaultContextSnapshot.java
+++ b/context-propagation/src/main/java/io/micrometer/context/DefaultContextSnapshot.java
@@ -92,6 +92,9 @@ final class DefaultContextSnapshot extends HashMap<Object, Object> implements Co
 
     @SuppressWarnings("unchecked")
     static <C> Scope setThreadLocalsFrom(Object context, ContextRegistry registry, String... keys) {
+        if (keys == null || keys.length == 0) {
+            throw new IllegalArgumentException("You must provide at least one key when setting thread locals");
+        }
         ContextAccessor<?, ?> contextAccessor = registry.getContextAccessorForRead(context);
         Map<Object, Object> previousValues = null;
         for (String key : keys) {

--- a/context-propagation/src/test/java/io/micrometer/context/DefaultContextSnapshotTests.java
+++ b/context-propagation/src/test/java/io/micrometer/context/DefaultContextSnapshotTests.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import io.micrometer.context.ContextSnapshot.Scope;
+import org.assertj.core.api.BDDAssertions;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -70,6 +71,30 @@ public class DefaultContextSnapshotTests {
         finally {
             ObservationThreadLocalHolder.reset();
         }
+    }
+
+    @Test
+    void should_throw_an_exception_when_no_keys_are_passed() {
+        this.registry.registerContextAccessor(new TestContextAccessor());
+        this.registry.registerThreadLocalAccessor(new ObservationThreadLocalAccessor());
+
+        Map<String, String> sourceContext = Collections.singletonMap("foo", "hello");
+
+        BDDAssertions.thenThrownBy(() -> ContextSnapshot.setThreadLocalsFrom(sourceContext, this.registry))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("You must provide at least one key when setting thread locals");
+    }
+
+    @Test
+    void should_throw_an_exception_when_no_keys_are_passed_for_version_with_no_registry() {
+        this.registry.registerContextAccessor(new TestContextAccessor());
+        this.registry.registerThreadLocalAccessor(new ObservationThreadLocalAccessor());
+
+        Map<String, String> sourceContext = Collections.singletonMap("foo", "hello");
+
+        BDDAssertions.thenThrownBy(() -> ContextSnapshot.setThreadLocalsFrom(sourceContext))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("You must provide at least one key when setting thread locals");
     }
 
     @Test


### PR DESCRIPTION
with this change it's mandatory to pass at least 1 key when calling ContextSnapshot.setThreadLocalsFrom method