### PR TITLE
Defer capture when wrapping ExecutorService and ScheduledExecutorService

### DIFF
--- a/context-propagation/src/main/java/io/micrometer/context/ContextPropagatingExecutorService.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ContextPropagatingExecutorService.java
@@ -41,15 +41,6 @@ class ContextPropagatingExecutorService<EXECUTOR extends ExecutorService> implem
     private final Supplier<ContextSnapshot> contextSnapshot;
 
     /**
-     * Create an instance of {@link ContextPropagatingScheduledExecutorService}. Will
-     * capture all {@link ContextSnapshot} when tasks are scheduled.
-     * @param executorService the {@code ExecutorService} to delegate to
-     */
-    ContextPropagatingExecutorService(EXECUTOR executorService) {
-        this(executorService, ContextSnapshot::captureAll);
-    }
-
-    /**
      * Create an instance of {@link ContextPropagatingScheduledExecutorService}.
      * @param executorService the {@code ExecutorService} to delegate to
      * @param contextSnapshot supplier of the {@link ContextSnapshot} - instruction on who

--- a/context-propagation/src/main/java/io/micrometer/context/ContextPropagatingScheduledExecutorService.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ContextPropagatingScheduledExecutorService.java
@@ -20,6 +20,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 /**
  * Wrap and delegate to an {@link ExecutorService} in order to instrument all tasks
@@ -35,11 +36,20 @@ final class ContextPropagatingScheduledExecutorService
     /**
      * Create an instance
      * @param executorService the {@code ScheduledExecutorService} to delegate to
-     * @param contextSnapshot the {@code ContextSnapshot} with values to propagate
+     * @param contextSnapshot supplier of the {@link ContextSnapshot} - instruction on who
+     * to retrieve {@link ContextSnapshot} when tasks are scheduled
      */
     ContextPropagatingScheduledExecutorService(ScheduledExecutorService executorService,
-            ContextSnapshot contextSnapshot) {
+            Supplier<ContextSnapshot> contextSnapshot) {
         super(executorService, contextSnapshot);
+    }
+
+    /**
+     * Create an instance
+     * @param executorService the {@code ScheduledExecutorService} to delegate to
+     */
+    ContextPropagatingScheduledExecutorService(ScheduledExecutorService executorService) {
+        super(executorService);
     }
 
     @Override

--- a/context-propagation/src/main/java/io/micrometer/context/ContextPropagatingScheduledExecutorService.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ContextPropagatingScheduledExecutorService.java
@@ -44,14 +44,6 @@ final class ContextPropagatingScheduledExecutorService
         super(executorService, contextSnapshot);
     }
 
-    /**
-     * Create an instance
-     * @param executorService the {@code ScheduledExecutorService} to delegate to
-     */
-    ContextPropagatingScheduledExecutorService(ScheduledExecutorService executorService) {
-        super(executorService);
-    }
-
     @Override
     public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
         return getExecutorService().schedule(getContextSnapshot().wrap(command), delay, unit);

--- a/context-propagation/src/main/java/io/micrometer/context/ContextSnapshot.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ContextSnapshot.java
@@ -124,48 +124,6 @@ public interface ContextSnapshot {
     }
 
     /**
-     * Return a new {@code ExecutorService} that sets {@code ThreadLocal} values from the
-     * snapshot around the invocation of any executed task.
-     * @param executorService the executorService to instrument
-     */
-    static ExecutorService wrapExecutorService(ExecutorService executorService) {
-        return new ContextPropagatingExecutorService<>(executorService);
-    }
-
-    /**
-     * Return a new {@code ExecutorService} that sets {@code ThreadLocal} values from the
-     * snapshot around the invocation of any executed task.
-     * @param executorService the executorService to instrument
-     * @param contextSnapshot supplier of the {@link ContextSnapshot} - instruction on who
-     * to retrieve {@link ContextSnapshot} when tasks are scheduled
-     */
-    static ExecutorService wrapExecutorService(ExecutorService executorService,
-            Supplier<ContextSnapshot> contextSnapshot) {
-        return new ContextPropagatingExecutorService<>(executorService, contextSnapshot);
-    }
-
-    /**
-     * Return a new {@code ScheduledExecutorService} that sets {@code ThreadLocal} values
-     * from the snapshot around the invocation of any executed task.
-     * @param scheduledExecutorService the scheduledExecutorService to instrument
-     */
-    static ScheduledExecutorService wrapScheduledExecutorService(ScheduledExecutorService scheduledExecutorService) {
-        return new ContextPropagatingScheduledExecutorService(scheduledExecutorService);
-    }
-
-    /**
-     * Return a new {@code ScheduledExecutorService} that sets {@code ThreadLocal} values
-     * from the snapshot around the invocation of any executed task.
-     * @param scheduledExecutorService the scheduledExecutorService to instrument
-     * @param contextSnapshot supplier of the {@link ContextSnapshot} - instruction on who
-     * to retrieve {@link ContextSnapshot} when tasks are scheduled
-     */
-    static ScheduledExecutorService wrapScheduledExecutorService(ScheduledExecutorService scheduledExecutorService,
-            Supplier<ContextSnapshot> contextSnapshot) {
-        return new ContextPropagatingScheduledExecutorService(scheduledExecutorService, contextSnapshot);
-    }
-
-    /**
      * Capture values from {@link ThreadLocal} and from other context objects using all
      * accessors from the {@link ContextRegistry#getInstance() global} ContextRegistry
      * instance.
@@ -282,6 +240,30 @@ public interface ContextSnapshot {
      */
     static Scope setThreadLocalsFrom(Object sourceContext, ContextRegistry contextRegistry, String... keys) {
         return DefaultContextSnapshot.setThreadLocalsFrom(sourceContext, contextRegistry, keys);
+    }
+
+    /**
+     * Return a new {@code ExecutorService} that sets {@code ThreadLocal} values from the
+     * snapshot around the invocation of any executed task.
+     * @param executorService the executorService to instrument
+     * @param contextSnapshot supplier of the {@link ContextSnapshot} - instruction on who
+     * to retrieve {@link ContextSnapshot} when tasks are scheduled
+     */
+    static ExecutorService wrapExecutorService(ExecutorService executorService,
+            Supplier<ContextSnapshot> contextSnapshot) {
+        return new ContextPropagatingExecutorService<>(executorService, contextSnapshot);
+    }
+
+    /**
+     * Return a new {@code ScheduledExecutorService} that sets {@code ThreadLocal} values
+     * from the snapshot around the invocation of any executed task.
+     * @param scheduledExecutorService the scheduledExecutorService to instrument
+     * @param contextSnapshot supplier of the {@link ContextSnapshot} - instruction on who
+     * to retrieve {@link ContextSnapshot} when tasks are scheduled
+     */
+    static ScheduledExecutorService wrapScheduledExecutorService(ScheduledExecutorService scheduledExecutorService,
+            Supplier<ContextSnapshot> contextSnapshot) {
+        return new ContextPropagatingScheduledExecutorService(scheduledExecutorService, contextSnapshot);
     }
 
     /**

--- a/context-propagation/src/main/java/io/micrometer/context/ContextSnapshot.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ContextSnapshot.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 /**
  * Holds values extracted from {@link ThreadLocal} and other types of context and exposes
@@ -127,8 +128,20 @@ public interface ContextSnapshot {
      * snapshot around the invocation of any executed task.
      * @param executorService the executorService to instrument
      */
-    default ExecutorService wrapExecutorService(ExecutorService executorService) {
-        return new ContextPropagatingExecutorService<>(executorService, this);
+    static ExecutorService wrapExecutorService(ExecutorService executorService) {
+        return new ContextPropagatingExecutorService<>(executorService);
+    }
+
+    /**
+     * Return a new {@code ExecutorService} that sets {@code ThreadLocal} values from the
+     * snapshot around the invocation of any executed task.
+     * @param executorService the executorService to instrument
+     * @param contextSnapshot supplier of the {@link ContextSnapshot} - instruction on who
+     * to retrieve {@link ContextSnapshot} when tasks are scheduled
+     */
+    static ExecutorService wrapExecutorService(ExecutorService executorService,
+            Supplier<ContextSnapshot> contextSnapshot) {
+        return new ContextPropagatingExecutorService<>(executorService, contextSnapshot);
     }
 
     /**
@@ -136,8 +149,20 @@ public interface ContextSnapshot {
      * from the snapshot around the invocation of any executed task.
      * @param scheduledExecutorService the scheduledExecutorService to instrument
      */
-    default ScheduledExecutorService wrapScheduledExecutorService(ScheduledExecutorService scheduledExecutorService) {
-        return new ContextPropagatingScheduledExecutorService(scheduledExecutorService, this);
+    static ScheduledExecutorService wrapScheduledExecutorService(ScheduledExecutorService scheduledExecutorService) {
+        return new ContextPropagatingScheduledExecutorService(scheduledExecutorService);
+    }
+
+    /**
+     * Return a new {@code ScheduledExecutorService} that sets {@code ThreadLocal} values
+     * from the snapshot around the invocation of any executed task.
+     * @param scheduledExecutorService the scheduledExecutorService to instrument
+     * @param contextSnapshot supplier of the {@link ContextSnapshot} - instruction on who
+     * to retrieve {@link ContextSnapshot} when tasks are scheduled
+     */
+    static ScheduledExecutorService wrapScheduledExecutorService(ScheduledExecutorService scheduledExecutorService,
+            Supplier<ContextSnapshot> contextSnapshot) {
+        return new ContextPropagatingScheduledExecutorService(scheduledExecutorService, contextSnapshot);
     }
 
     /**


### PR DESCRIPTION
without this fix we're capturing the ThreadLocals at the moment of creation of the executorservice. That can contain already some value of the thread local that will then always be reused when tasks are scheduled.

with this change we're doing the wrapping at the moment of task scheduling. That way we're sure that we're capturing from ThreadLocal the most recently entered values