### PR TITLE
Adds restore ThreadLocalAccessor method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,6 @@ apply from: 'dependencies.gradle'
 
 allprojects {
 	group = 'io.micrometer'
-	version = "1.0.1-SNAPSHOT"
 	ext.'release.stage' = releaseStage ?: 'SNAPSHOT'
 
 	afterEvaluate { project -> println "I'm configuring $project.name with version $project.version" }

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ apply from: 'dependencies.gradle'
 
 allprojects {
 	group = 'io.micrometer'
+	version = "1.0.1-SNAPSHOT"
 	ext.'release.stage' = releaseStage ?: 'SNAPSHOT'
 
 	afterEvaluate { project -> println "I'm configuring $project.name with version $project.version" }

--- a/context-propagation/src/main/java/io/micrometer/context/DefaultContextSnapshot.java
+++ b/context-propagation/src/main/java/io/micrometer/context/DefaultContextSnapshot.java
@@ -193,7 +193,7 @@ final class DefaultContextSnapshot extends HashMap<Object, Object> implements Co
         @SuppressWarnings("unchecked")
         private <V> void resetThreadLocalValue(ThreadLocalAccessor<?> accessor, @Nullable V previousValue) {
             if (previousValue != null) {
-                ((ThreadLocalAccessor<V>) accessor).setValue(previousValue);
+                ((ThreadLocalAccessor<V>) accessor).restore(previousValue);
             }
             else {
                 accessor.reset();

--- a/context-propagation/src/main/java/io/micrometer/context/ThreadLocalAccessor.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ThreadLocalAccessor.java
@@ -54,4 +54,12 @@ public interface ThreadLocalAccessor<V> {
      */
     void reset();
 
+    /**
+     * Remove the {@link ThreadLocal} value and set a new one
+     * @param previousValue previous value to set
+     */
+    default void restore(V previousValue) {
+        setValue(previousValue);
+    }
+
 }

--- a/context-propagation/src/main/java/io/micrometer/context/ThreadLocalAccessor.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ThreadLocalAccessor.java
@@ -38,7 +38,7 @@ public interface ThreadLocalAccessor<V> {
     Object key();
 
     /**
-     * Return the {@link ThreadLocal} value, or {@code null} if not set.
+     * Return the current {@link ThreadLocal} value, or {@code null} if not set.
      */
     @Nullable
     V getValue();
@@ -55,7 +55,7 @@ public interface ThreadLocalAccessor<V> {
     void reset();
 
     /**
-     * Remove the {@link ThreadLocal} value and set a new one
+     * Remove the current {@link ThreadLocal} value and set the previously stored one.
      * @param previousValue previous value to set
      */
     default void restore(V previousValue) {


### PR DESCRIPTION
with the current implementation of `DefaultContextSnapshot` we can't discern between setting a value for the first time and restoring the previous value. In case of observations and opening scopes that is an important distinction cause for setting we want to open a scope and for setting a previous scope we need to close the current one.

This commit adds a new method, it's a non-breaking change.