### PR TITLE
Add Javadoc since for ThreadLocalAccessor.restore()

### DIFF
--- a/context-propagation/src/main/java/io/micrometer/context/ThreadLocalAccessor.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ThreadLocalAccessor.java
@@ -57,6 +57,7 @@ public interface ThreadLocalAccessor<V> {
     /**
      * Remove the current {@link ThreadLocal} value and set the previously stored one.
      * @param previousValue previous value to set
+     * @Since 1.0.1
      */
     default void restore(V previousValue) {
         setValue(previousValue);


### PR DESCRIPTION
This PR adds Javadoc `@since` tag for `ThreadLocalAccessor.restore()`.

See gh-68