### PR TITLE
Add ContextSnapshot.captureFromMany variants

### DIFF
--- a/context-propagation/src/main/java/io/micrometer/context/ContextSnapshot.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ContextSnapshot.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 the original author or authors.
+ * Copyright 2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import java.util.function.Predicate;
  * Use static factory methods on this interface to create a snapshot.
  *
  * @author Rossen Stoyanchev
+ * @author Brian Clozel
  * @since 1.0.0
  */
 public interface ContextSnapshot {
@@ -169,18 +170,45 @@ public interface ContextSnapshot {
     }
 
     /**
+     * Create a {@link ContextSnapshot} by reading values from the given context objects.
+     * <p>
+     * Values captured multiple times are overridden in the snapshot by the order of
+     * contexts given as arguments.
+     * @param contexts the contexts to read values from
+     * @return the created {@link ContextSnapshot}
+     */
+    static ContextSnapshot captureFromMany(Object... contexts) {
+        return DefaultContextSnapshot.captureFromMany(key -> true, ContextRegistry.getInstance(), contexts);
+    }
+
+    /**
      * Create a {@link ContextSnapshot} by reading values from the given context object.
      * @param context the context to read values from
      * @param registry the registry to use
      * @return the created {@link ContextSnapshot}
      */
     static ContextSnapshot captureFrom(Object context, ContextRegistry registry) {
-        return captureFrom(context, key -> true, registry);
+        return DefaultContextSnapshot.captureFromContext(key -> true, registry, context, null);
+    }
+
+    /**
+     * Create a {@link ContextSnapshot} by reading values from the given context objects.
+     * <p>
+     * Values captured multiple times are overridden in the snapshot by the order of
+     * contexts given as arguments.
+     * @param registry the registry to use
+     * @param contexts the contexts to read values from
+     * @return the created {@link ContextSnapshot}
+     */
+    static ContextSnapshot captureFromMany(ContextRegistry registry, Object... contexts) {
+        return DefaultContextSnapshot.captureFromMany(key -> true, registry, contexts);
     }
 
     /**
      * Create a {@link ContextSnapshot} by reading values from the given context object.
      * @param context the context to read values from
+     * @param keyPredicate predicate for context value keys
+     * @param registry the registry to use
      * @return the created {@link ContextSnapshot}
      */
     static ContextSnapshot captureFrom(Object context, Predicate<Object> keyPredicate, ContextRegistry registry) {

--- a/context-propagation/src/main/java/io/micrometer/context/ContextSnapshot.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ContextSnapshot.java
@@ -164,7 +164,9 @@ public interface ContextSnapshot {
      * Create a {@link ContextSnapshot} by reading values from the given context object.
      * @param context the context to read values from
      * @return the created {@link ContextSnapshot}
+     * @deprecated as of 1.0.3 in favor of {@link #captureFromContext(Object...)}
      */
+    @Deprecated
     static ContextSnapshot captureFrom(Object context) {
         return captureFrom(context, ContextRegistry.getInstance());
     }
@@ -177,8 +179,8 @@ public interface ContextSnapshot {
      * @param contexts the contexts to read values from
      * @return the created {@link ContextSnapshot}
      */
-    static ContextSnapshot captureFromMany(Object... contexts) {
-        return DefaultContextSnapshot.captureFromMany(key -> true, ContextRegistry.getInstance(), contexts);
+    static ContextSnapshot captureFromContext(Object... contexts) {
+        return DefaultContextSnapshot.captureFromContexts(key -> true, ContextRegistry.getInstance(), contexts);
     }
 
     /**
@@ -186,7 +188,10 @@ public interface ContextSnapshot {
      * @param context the context to read values from
      * @param registry the registry to use
      * @return the created {@link ContextSnapshot}
+     * @deprecated as of 1.0.3 in favor of
+     * {@link #captureFromContext(ContextRegistry, Object...)}
      */
+    @Deprecated
     static ContextSnapshot captureFrom(Object context, ContextRegistry registry) {
         return DefaultContextSnapshot.captureFromContext(key -> true, registry, context, null);
     }
@@ -200,8 +205,8 @@ public interface ContextSnapshot {
      * @param contexts the contexts to read values from
      * @return the created {@link ContextSnapshot}
      */
-    static ContextSnapshot captureFromMany(ContextRegistry registry, Object... contexts) {
-        return DefaultContextSnapshot.captureFromMany(key -> true, registry, contexts);
+    static ContextSnapshot captureFromContext(ContextRegistry registry, Object... contexts) {
+        return DefaultContextSnapshot.captureFromContexts(key -> true, registry, contexts);
     }
 
     /**
@@ -210,9 +215,27 @@ public interface ContextSnapshot {
      * @param keyPredicate predicate for context value keys
      * @param registry the registry to use
      * @return the created {@link ContextSnapshot}
+     * @deprecated as of 1.0.3 in favor of
+     * {@link #captureFromContext(Predicate, ContextRegistry, Object...)}
      */
+    @Deprecated
     static ContextSnapshot captureFrom(Object context, Predicate<Object> keyPredicate, ContextRegistry registry) {
         return DefaultContextSnapshot.captureFromContext(keyPredicate, registry, context, null);
+    }
+
+    /**
+     * Create a {@link ContextSnapshot} by reading values from the given context objects.
+     * <p>
+     * Values captured multiple times are overridden in the snapshot by the order of
+     * contexts given as arguments.
+     * @param keyPredicate predicate for context value keys
+     * @param registry the registry to use
+     * @param contexts the contexts to read values from
+     * @return the created {@link ContextSnapshot}
+     */
+    static ContextSnapshot captureFromContext(Predicate<Object> keyPredicate, ContextRegistry registry,
+            Object... contexts) {
+        return DefaultContextSnapshot.captureFromContexts(keyPredicate, registry, contexts);
     }
 
     /**

--- a/context-propagation/src/main/java/io/micrometer/context/DefaultContextSnapshot.java
+++ b/context-propagation/src/main/java/io/micrometer/context/DefaultContextSnapshot.java
@@ -152,7 +152,7 @@ final class DefaultContextSnapshot extends HashMap<Object, Object> implements Co
         return snapshot;
     }
 
-    static ContextSnapshot captureFromMany(Predicate<Object> keyPredicate, ContextRegistry contextRegistry,
+    static ContextSnapshot captureFromContexts(Predicate<Object> keyPredicate, ContextRegistry contextRegistry,
             Object... contexts) {
         DefaultContextSnapshot snapshot = null;
         for (Object context : contexts) {

--- a/context-propagation/src/main/java/io/micrometer/context/DefaultContextSnapshot.java
+++ b/context-propagation/src/main/java/io/micrometer/context/DefaultContextSnapshot.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 the original author or authors.
+ * Copyright 2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.function.Predicate;
  * Default implementation of {@link ContextSnapshot}.
  *
  * @author Rossen Stoyanchev
+ * @author Brian Clozel
  * @since 1.0.0
  */
 final class DefaultContextSnapshot extends HashMap<Object, Object> implements ContextSnapshot {
@@ -149,6 +150,15 @@ final class DefaultContextSnapshot extends HashMap<Object, Object> implements Co
             }
         }
         return snapshot;
+    }
+
+    static ContextSnapshot captureFromMany(Predicate<Object> keyPredicate, ContextRegistry contextRegistry,
+            Object... contexts) {
+        DefaultContextSnapshot snapshot = null;
+        for (Object context : contexts) {
+            snapshot = captureFromContext(keyPredicate, contextRegistry, context, snapshot);
+        }
+        return (snapshot != null ? snapshot : emptyContextSnapshot);
     }
 
     @SuppressWarnings("unchecked")

--- a/context-propagation/src/test/java/io/micrometer/context/DefaultContextSnapshotTests.java
+++ b/context-propagation/src/test/java/io/micrometer/context/DefaultContextSnapshotTests.java
@@ -101,7 +101,7 @@ public class DefaultContextSnapshotTests {
         Map<String, String> firstContext = Collections.singletonMap(key, "hello");
         Map<String, String> secondContext = Collections.singletonMap(key, "override");
         try {
-            ContextSnapshot contextSnapshot = ContextSnapshot.captureFromMany(this.registry, firstContext,
+            ContextSnapshot contextSnapshot = ContextSnapshot.captureFromContext(this.registry, firstContext,
                     secondContext);
             contextSnapshot.wrap(() -> {
                 then(ObservationThreadLocalHolder.getValue()).isEqualTo("override");

--- a/context-propagation/src/test/java/io/micrometer/context/DefaultContextSnapshotTests.java
+++ b/context-propagation/src/test/java/io/micrometer/context/DefaultContextSnapshotTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 the original author or authors.
+ * Copyright 2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,6 +87,25 @@ public class DefaultContextSnapshotTests {
                 then(ObservationThreadLocalHolder.getValue()).isEqualTo("hello");
             }
             then(ObservationThreadLocalHolder.getValue()).isEqualTo("hola");
+        }
+        finally {
+            ObservationThreadLocalHolder.reset();
+        }
+    }
+
+    @Test
+    void should_override_context_values_when_many_contexts() {
+        this.registry.registerContextAccessor(new TestContextAccessor());
+
+        String key = ObservationThreadLocalAccessor.KEY;
+        Map<String, String> firstContext = Collections.singletonMap(key, "hello");
+        Map<String, String> secondContext = Collections.singletonMap(key, "override");
+        try {
+            ContextSnapshot contextSnapshot = ContextSnapshot.captureFromMany(this.registry, firstContext,
+                    secondContext);
+            contextSnapshot.wrap(() -> {
+                then(ObservationThreadLocalHolder.getValue()).isEqualTo("override");
+            });
         }
         finally {
             ObservationThreadLocalHolder.reset();


### PR DESCRIPTION
Prior to this commit, `ContextSnapshot` would only allow to capture from
a single context, unless the `captureAll` variants which involve
`ThreadLocal` capture.

This commit introduces new `captureFromMany` methods for this, since
introducing varargs variants for `captureFrom` would break existing
applications.
This new method allows to capture a context snapshot from multiple
contexts (without capturing from threadlocals). If a particular
key is present in multiple contexts, it will be overriden as values are
extracted.
