### PR TITLE
More fine grained ThreadLocalAccessor API

### DIFF
--- a/context-propagation/src/main/java/io/micrometer/context/DefaultContextSnapshot.java
+++ b/context-propagation/src/main/java/io/micrometer/context/DefaultContextSnapshot.java
@@ -83,12 +83,17 @@ final class DefaultContextSnapshot extends HashMap<Object, Object> implements Co
     }
 
     @SuppressWarnings("unchecked")
-    private static <V> Map<Object, Object> setThreadLocal(Object key, V value, ThreadLocalAccessor<?> accessor,
-            @Nullable Map<Object, Object> previousValues) {
+    private static <V> Map<Object, Object> setThreadLocal(Object key, @Nullable V value,
+            ThreadLocalAccessor<?> accessor, @Nullable Map<Object, Object> previousValues) {
 
         previousValues = (previousValues != null ? previousValues : new HashMap<>());
         previousValues.put(key, accessor.getValue());
-        ((ThreadLocalAccessor<V>) accessor).setValue(value);
+        if (value != null) {
+            ((ThreadLocalAccessor<V>) accessor).setValue(value);
+        }
+        else {
+            accessor.resetToSetValue();
+        }
         return previousValues;
     }
 
@@ -200,7 +205,7 @@ final class DefaultContextSnapshot extends HashMap<Object, Object> implements Co
                 ((ThreadLocalAccessor<V>) accessor).restore(previousValue);
             }
             else {
-                accessor.reset();
+                accessor.resetToRestore();
             }
         }
 

--- a/context-propagation/src/main/java/io/micrometer/context/ThreadLocalAccessor.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ThreadLocalAccessor.java
@@ -50,9 +50,13 @@ public interface ThreadLocalAccessor<V> {
     void setValue(V value);
 
     /**
-     * Remove the {@link ThreadLocal} value.
+     * Call this instead of {@link #setValue(Object)} with {@code null} in order to remove
+     * the {@link ThreadLocal}.
+     * @since 1.0.3
      */
-    void reset();
+    default void resetToSetValue() {
+        reset();
+    }
 
     /**
      * Remove the current {@link ThreadLocal} value and set the previously stored one.
@@ -62,5 +66,19 @@ public interface ThreadLocalAccessor<V> {
     default void restore(V previousValue) {
         setValue(previousValue);
     }
+
+    /**
+     * Call this instead of {@link #restore(Object)} with {@code null} in order to remove
+     * the {@link ThreadLocal}.
+     * @since 1.0.3
+     */
+    default void resetToRestore() {
+        reset();
+    }
+
+    /**
+     * Remove the {@link ThreadLocal} value.
+     */
+    void reset();
 
 }

--- a/context-propagation/src/test/java/io/micrometer/context/ContextWrappingTests.java
+++ b/context-propagation/src/test/java/io/micrometer/context/ContextWrappingTests.java
@@ -38,16 +38,16 @@ import static org.assertj.core.api.BDDAssertions.then;
 class ContextWrappingTests {
 
     private final ContextRegistry registry = new ContextRegistry()
-        .registerThreadLocalAccessor(new ObservationThreadLocalAccessor());
+        .registerThreadLocalAccessor(new StringThreadLocalAccessor());
 
     @AfterEach
     void clear() {
-        ObservationThreadLocalHolder.reset();
+        StringThreadLocalHolder.reset();
     }
 
     @Test
     void should_instrument_runnable() throws InterruptedException {
-        ObservationThreadLocalHolder.setValue("hello");
+        StringThreadLocalHolder.setValue("hello");
         AtomicReference<String> valueInNewThread = new AtomicReference<>();
         Runnable runnable = runnable(valueInNewThread);
         runInNewThread(runnable);
@@ -61,10 +61,10 @@ class ContextWrappingTests {
 
     @Test
     void should_instrument_callable() throws ExecutionException, InterruptedException, TimeoutException {
-        ObservationThreadLocalHolder.setValue("hello");
+        StringThreadLocalHolder.setValue("hello");
         AtomicReference<String> valueInNewThread = new AtomicReference<>();
         Callable<String> callable = () -> {
-            valueInNewThread.set(ObservationThreadLocalHolder.getValue());
+            valueInNewThread.set(StringThreadLocalHolder.getValue());
             return "foo";
         };
         runInNewThread(callable);
@@ -78,7 +78,7 @@ class ContextWrappingTests {
 
     @Test
     void should_instrument_executor() throws InterruptedException {
-        ObservationThreadLocalHolder.setValue("hello");
+        StringThreadLocalHolder.setValue("hello");
         AtomicReference<String> valueInNewThread = new AtomicReference<>();
         Executor executor = command -> new Thread(command).start();
         runInNewThread(executor, valueInNewThread);
@@ -95,7 +95,7 @@ class ContextWrappingTests {
     void should_instrument_executor_service() throws InterruptedException, ExecutionException, TimeoutException {
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         try {
-            ObservationThreadLocalHolder.setValue("hello");
+            StringThreadLocalHolder.setValue("hello");
             AtomicReference<String> valueInNewThread = new AtomicReference<>();
             runInNewThread(executorService, valueInNewThread,
                     atomic -> then(atomic.get()).as("By default thread local information should not be propagated")
@@ -119,13 +119,13 @@ class ContextWrappingTests {
             throws InterruptedException, ExecutionException, TimeoutException {
         ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
         try {
-            ObservationThreadLocalHolder.setValue("hello at time of creation of the executor");
+            StringThreadLocalHolder.setValue("hello at time of creation of the executor");
             AtomicReference<String> valueInNewThread = new AtomicReference<>();
             runInNewThread(executorService, valueInNewThread,
                     atomic -> then(atomic.get()).as("By default thread local information should not be propagated")
                         .isNull());
 
-            ObservationThreadLocalHolder.setValue("hello at time of creation of the executor");
+            StringThreadLocalHolder.setValue("hello at time of creation of the executor");
             runInNewThread(
                     ContextExecutorService
                         .wrap(executorService, () -> ContextSnapshot.captureAllUsing(key -> true, this.registry)),
@@ -166,9 +166,9 @@ class ContextWrappingTests {
             Consumer<AtomicReference<String>> assertion)
             throws InterruptedException, ExecutionException, TimeoutException {
 
-        ObservationThreadLocalHolder.setValue("hello"); // IMPORTANT: We are setting the
-                                                        // thread local value as late as
-                                                        // possible
+        StringThreadLocalHolder.setValue("hello"); // IMPORTANT: We are setting the
+                                                   // thread local value as late as
+                                                   // possible
         executor.execute(runnable(valueInNewThread));
         Thread.sleep(5);
         assertion.accept(valueInNewThread);
@@ -215,12 +215,12 @@ class ContextWrappingTests {
     }
 
     private Runnable runnable(AtomicReference<String> valueInNewThread) {
-        return () -> valueInNewThread.set(ObservationThreadLocalHolder.getValue());
+        return () -> valueInNewThread.set(StringThreadLocalHolder.getValue());
     }
 
     private Callable<Object> callable(AtomicReference<String> valueInNewThread) {
         return () -> {
-            valueInNewThread.set(ObservationThreadLocalHolder.getValue());
+            valueInNewThread.set(StringThreadLocalHolder.getValue());
             return "foo";
         };
     }

--- a/context-propagation/src/test/java/io/micrometer/context/StringThreadLocalAccessor.java
+++ b/context-propagation/src/test/java/io/micrometer/context/StringThreadLocalAccessor.java
@@ -18,9 +18,9 @@ package io.micrometer.context;
 /**
  * Example {@link ThreadLocalAccessor} implementation.
  */
-public class ObservationThreadLocalAccessor implements ThreadLocalAccessor<String> {
+public class StringThreadLocalAccessor implements ThreadLocalAccessor<String> {
 
-    public static final String KEY = "micrometer.observation";
+    public static final String KEY = "string.threadlocal";
 
     @Override
     public Object key() {
@@ -29,17 +29,17 @@ public class ObservationThreadLocalAccessor implements ThreadLocalAccessor<Strin
 
     @Override
     public String getValue() {
-        return ObservationThreadLocalHolder.getValue();
+        return StringThreadLocalHolder.getValue();
     }
 
     @Override
     public void setValue(String value) {
-        ObservationThreadLocalHolder.setValue(value);
+        StringThreadLocalHolder.setValue(value);
     }
 
     @Override
     public void reset() {
-        ObservationThreadLocalHolder.reset();
+        StringThreadLocalHolder.reset();
     }
 
 }

--- a/context-propagation/src/test/java/io/micrometer/context/StringThreadLocalHolder.java
+++ b/context-propagation/src/test/java/io/micrometer/context/StringThreadLocalHolder.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.context;
+
+public class StringThreadLocalHolder {
+
+    private static final ThreadLocal<String> holder = new ThreadLocal<>();
+
+    public static void resetValue() {
+        holder.remove();
+    }
+
+    public static void setValue(String value) {
+        holder.set(value);
+    }
+
+    public static String getValue() {
+        return holder.get();
+    }
+
+    public static void reset() {
+        holder.remove();
+    }
+
+}

--- a/context-propagation/src/test/java/io/micrometer/context/observation/NullObservation.java
+++ b/context-propagation/src/test/java/io/micrometer/context/observation/NullObservation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 the original author or authors.
+ * Copyright 2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,26 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.context;
+package io.micrometer.context.observation;
 
-public class ObservationThreadLocalHolder {
+class NullObservation extends Observation {
 
-    private static final ThreadLocal<String> holder = new ThreadLocal<>();
-
-    public static void resetValue() {
-        holder.remove();
-    }
-
-    public static void setValue(String value) {
-        holder.set(value);
-    }
-
-    public static String getValue() {
-        return holder.get();
-    }
-
-    public static void reset() {
-        holder.remove();
+    Scope openScope() {
+        return new RevertingScope(null);
     }
 
 }

--- a/context-propagation/src/test/java/io/micrometer/context/observation/Observation.java
+++ b/context-propagation/src/test/java/io/micrometer/context/observation/Observation.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.context.observation;
+
+public class Observation {
+
+    Scope openScope() {
+        return new RevertingScope(this);
+    }
+
+}

--- a/context-propagation/src/test/java/io/micrometer/context/observation/ObservationScopeThreadLocalHolder.java
+++ b/context-propagation/src/test/java/io/micrometer/context/observation/ObservationScopeThreadLocalHolder.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.context.observation;
+
+public class ObservationScopeThreadLocalHolder {
+
+    private static final ThreadLocal<Scope> holder = new ThreadLocal<>();
+
+    public static void setValue(Scope value) {
+        holder.set(value);
+    }
+
+    public static Scope getValue() {
+        return holder.get();
+    }
+
+    public static Observation getCurrentObservation() {
+        Scope scope = holder.get();
+        if (scope != null) {
+            return scope.getCurrentObservation();
+        }
+        return null;
+    }
+
+}

--- a/context-propagation/src/test/java/io/micrometer/context/observation/ObservationThreadLocalAccessor.java
+++ b/context-propagation/src/test/java/io/micrometer/context/observation/ObservationThreadLocalAccessor.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.context.observation;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import io.micrometer.context.ThreadLocalAccessor;
+
+/**
+ * Example {@link ThreadLocalAccessor} implementation.
+ */
+public class ObservationThreadLocalAccessor implements ThreadLocalAccessor<Observation> {
+
+    private static final Logger log = Logger.getLogger(ObservationThreadLocalAccessor.class.getName());
+
+    public static final String KEY = "micrometer.observation";
+
+    @Override
+    public Object key() {
+        return KEY;
+    }
+
+    @Override
+    public Observation getValue() {
+        return ObservationScopeThreadLocalHolder.getCurrentObservation();
+    }
+
+    @Override
+    public void setValue(Observation value) {
+        value.openScope();
+    }
+
+    @Override
+    public void resetToSetValue() {
+        new NullObservation().openScope();
+    }
+
+    @Override
+    public void restore(Observation value) {
+        Scope scope = ObservationScopeThreadLocalHolder.getValue();
+        if (scope == null) {
+            String msg = "There is no current scope in thread local. This situation should not happen";
+            log.log(Level.WARNING, msg);
+            assert false : msg;
+        }
+        Scope previousObservationScope = scope.getPreviousObservationScope();
+        if (previousObservationScope == null || value != previousObservationScope.getCurrentObservation()) {
+            Observation previousObservation = previousObservationScope != null
+                    ? previousObservationScope.getCurrentObservation() : null;
+            String msg = "Observation <" + value
+                    + "> to which we're restoring is not the same as the one set as this scope's parent observation <"
+                    + previousObservation
+                    + "> . Most likely a manually created Observation has a scope opened that was never closed. This may lead to thread polluting and memory leaks";
+            log.log(Level.WARNING, msg);
+            assert false : msg;
+        }
+        reset();
+    }
+
+    @Override
+    public void resetToRestore() {
+        reset();
+    }
+
+    @Override
+    public void reset() {
+        Scope scope = ObservationScopeThreadLocalHolder.getValue();
+        if (scope != null) {
+            scope.close();
+        }
+    }
+
+}

--- a/context-propagation/src/test/java/io/micrometer/context/observation/RevertingScope.java
+++ b/context-propagation/src/test/java/io/micrometer/context/observation/RevertingScope.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.context.observation;
+
+class RevertingScope implements Scope {
+
+    private final Scope previousScope;
+
+    private final Observation observation;
+
+    RevertingScope(Observation observation) {
+        this.previousScope = ObservationScopeThreadLocalHolder.getValue();
+        this.observation = observation;
+        ObservationScopeThreadLocalHolder.setValue(this);
+    }
+
+    @Override
+    public void close() {
+        ObservationScopeThreadLocalHolder.setValue(this.previousScope);
+    }
+
+    @Override
+    public Scope getPreviousObservationScope() {
+        return this.previousScope;
+    }
+
+    @Override
+    public Observation getCurrentObservation() {
+        return this.observation;
+    }
+
+}

--- a/context-propagation/src/test/java/io/micrometer/context/observation/Scope.java
+++ b/context-propagation/src/test/java/io/micrometer/context/observation/Scope.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.context.observation;
+
+import java.io.Closeable;
+
+interface Scope extends Closeable {
+
+    Observation getCurrentObservation();
+
+    Scope getPreviousObservationScope();
+
+    @Override
+    void close();
+
+}


### PR DESCRIPTION
without this change we're using the same ThreadLocalAccessor methods when a null value should be set or we should reset the current value

with this change we're introducing new methods to the ThreadLocalAccessor class that give more fine grained control over what should be done in cases of
- setting a concrete value when scope is opened
- resetting a concrete value when scope is opened (e.g. create a nullscope)
- closing a scope when there was an object when we started a scope
- closing a scope when there was no object when we started a scope

if you're not interested in scopes you will still use the original methods
- getValue
- setValue
- reset

this is a non-breaking change