### PR TITLE
Disallowing null values in ContextSnapshot

### DIFF
--- a/context-propagation/src/main/java/io/micrometer/context/ContextAccessor.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ContextAccessor.java
@@ -27,7 +27,7 @@ import java.util.function.Predicate;
  * Implementations are disallowed to read {@code null} values into the given storage. This
  * requirement comes from the nature of {@link ThreadLocal}: if a value was not set, or
  * it's value is {@code null}, there is no way of distinguishing one from the other. In
- * such a case, the {@link ContextSnapshot} simply doesn't contain a capture fpr the
+ * such a case, the {@link ContextSnapshot} simply doesn't contain a capture for the
  * particular {@link ThreadLocal}. Due to this limitation, {@link ContextAccessor} should
  * not operate on {@code null} values. On the writing side, the implementations are safe
  * to assume the provided mappings do not contain mapping to {@code null}.

--- a/context-propagation/src/main/java/io/micrometer/context/ContextAccessor.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ContextAccessor.java
@@ -23,15 +23,6 @@ import java.util.function.Predicate;
  * Reactor {@code Context}, including the ability to read values from it a {@link Map} and
  * to write values to it from a {@link Map}.
  *
- * <p>
- * Implementations are disallowed to read {@code null} values into the given storage. This
- * requirement comes from the nature of {@link ThreadLocal}: if a value was not set, or
- * it's value is {@code null}, there is no way of distinguishing one from the other. In
- * such a case, the {@link ContextSnapshot} simply doesn't contain a capture for the
- * particular {@link ThreadLocal}. Due to this limitation, {@link ContextAccessor} should
- * not operate on {@code null} values. On the writing side, the implementations are safe
- * to assume the provided mappings do not contain mapping to {@code null}.
- *
  * @param <READ> type of context for reading
  * @param <WRITE> type of context for writing
  * @author Marcin Grzejszczak
@@ -52,7 +43,9 @@ public interface ContextAccessor<READ, WRITE> {
      * {@link Class#isAssignableFrom(Class) assignable} from the type returned by
      * {@link #readableType()}.
      * <p>
-     * It is forbidden to store {@code} values in the provided {@link Map}.
+     * When an {@link ContextAccessor} is used to populate a {@link ContextSnapshot}, the
+     * snapshot implementations are required to filter out {@code null} mappings, so it is
+     * not required to implement special handling in the accessor.
      * @param keyPredicate a predicate to decide which keys to read
      * @param readValues a map where to put read values
      */
@@ -64,7 +57,7 @@ public interface ContextAccessor<READ, WRITE> {
      * {@link Class#isAssignableFrom(Class) assignable} from the type returned by
      * {@link #readableType()}.
      * @param key the key to use to look up the context value
-     * @return the value, if present, or {@code null} when not
+     * @return the value, if present
      */
     @Nullable
     <T> T readValue(READ sourceContext, Object key);
@@ -76,8 +69,7 @@ public interface ContextAccessor<READ, WRITE> {
 
     /**
      * Write values from a {@link Map} to a target context.
-     * @param valuesToWrite the values to write to the target context. Implementations can
-     * assume there is no mapping to {@code null}.
+     * @param valuesToWrite the values to write to the target context.
      * @param targetContext the context to write to; the context type should be
      * {@link Class#isAssignableFrom(Class) assignable} from the type returned by
      * {@link #writeableType()}.

--- a/context-propagation/src/main/java/io/micrometer/context/ContextAccessor.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ContextAccessor.java
@@ -24,14 +24,13 @@ import java.util.function.Predicate;
  * to write values to it from a {@link Map}.
  *
  * <p>
- * Implementations are disallowed to read {@code null} values into the given storage.
- * This requirement comes from the nature of {@link ThreadLocal}: if a
- * value was not set, or it's value is {@code null}, there is no way of
- * distinguishing one from the other. In such a case, the {@link ContextSnapshot}
- * simply doesn't contain a capture fpr the particular {@link ThreadLocal}. Due to this
- * limitation, {@link ContextAccessor} should not operate on {@code null} values.
- * On the writing side, the implementations are safe to assume the provided mappings do
- * not contain mapping to {@code null}.
+ * Implementations are disallowed to read {@code null} values into the given storage. This
+ * requirement comes from the nature of {@link ThreadLocal}: if a value was not set, or
+ * it's value is {@code null}, there is no way of distinguishing one from the other. In
+ * such a case, the {@link ContextSnapshot} simply doesn't contain a capture fpr the
+ * particular {@link ThreadLocal}. Due to this limitation, {@link ContextAccessor} should
+ * not operate on {@code null} values. On the writing side, the implementations are safe
+ * to assume the provided mappings do not contain mapping to {@code null}.
  *
  * @param <READ> type of context for reading
  * @param <WRITE> type of context for writing
@@ -77,8 +76,8 @@ public interface ContextAccessor<READ, WRITE> {
 
     /**
      * Write values from a {@link Map} to a target context.
-     * @param valuesToWrite the values to write to the target context. Implementations
-     *                      can assume there is no mapping to {@code null}.
+     * @param valuesToWrite the values to write to the target context. Implementations can
+     * assume there is no mapping to {@code null}.
      * @param targetContext the context to write to; the context type should be
      * {@link Class#isAssignableFrom(Class) assignable} from the type returned by
      * {@link #writeableType()}.

--- a/context-propagation/src/main/java/io/micrometer/context/ContextSnapshot.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ContextSnapshot.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.context;
 
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
@@ -27,11 +28,10 @@ import java.util.function.Predicate;
  * <p>
  * Implementations are disallowed to store {@code null} values. If a {@link ThreadLocal}
  * is not set, or it's value is {@code null}, there is no way of distinguishing one from
- * the other. In such a case, the {@link ContextSnapshot} simply doesn't contain a capture
- * fpr the particular {@link ThreadLocal}. Due to this limitation, other types of context
- * accessed via {@link ContextAccessor} should not operate on {@code null} values.
- * Implementations should still make an effort and prevent storing {@code null} in the
- * snapshot in case a {@link ContextAccessor} doesn't comply with this requirement.
+ * the other. In such a case, the {@link ContextSnapshot} simply must not contain a
+ * capture for the particular {@link ThreadLocal}. Implementations should filter out any
+ * {@code null} values after reading into the storage also obtained by calling
+ * {@link ContextAccessor#readValues(Object, Predicate, Map)}.
  *
  * <p>
  * Use static factory methods on this interface to create a snapshot.

--- a/context-propagation/src/main/java/io/micrometer/context/ContextSnapshot.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ContextSnapshot.java
@@ -25,14 +25,13 @@ import java.util.function.Predicate;
  * methods to propagate those values.
  *
  * <p>
- * Implementations are disallowed to store {@code null} values. If a
- * {@link ThreadLocal} is not set, or it's value is {@code null}, there is no way of
- * distinguishing one from the other. In such a case, the {@link ContextSnapshot}
- * simply doesn't contain a capture fpr the particular {@link ThreadLocal}. Due to this
- * limitation, other types of context accessed via {@link ContextAccessor} should not
- * operate on {@code null} values. Implementations should still make an effort and
- * prevent storing {@code null} in the snapshot in case a {@link ContextAccessor}
- * doesn't comply with this requirement.
+ * Implementations are disallowed to store {@code null} values. If a {@link ThreadLocal}
+ * is not set, or it's value is {@code null}, there is no way of distinguishing one from
+ * the other. In such a case, the {@link ContextSnapshot} simply doesn't contain a capture
+ * fpr the particular {@link ThreadLocal}. Due to this limitation, other types of context
+ * accessed via {@link ContextAccessor} should not operate on {@code null} values.
+ * Implementations should still make an effort and prevent storing {@code null} in the
+ * snapshot in case a {@link ContextAccessor} doesn't comply with this requirement.
  *
  * <p>
  * Use static factory methods on this interface to create a snapshot.

--- a/context-propagation/src/main/java/io/micrometer/context/ContextSnapshot.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ContextSnapshot.java
@@ -31,7 +31,8 @@ import java.util.function.Predicate;
  * the other. In such a case, the {@link ContextSnapshot} simply must not contain a
  * capture for the particular {@link ThreadLocal}. Implementations should filter out any
  * {@code null} values after reading into the storage also obtained by calling
- * {@link ContextAccessor#readValues(Object, Predicate, Map)}.
+ * {@link ContextAccessor#readValues(Object, Predicate, Map)}, and should likewise ignore
+ * {@code null} values from {@link ContextAccessor#readValue(Object, Object)}.
  *
  * <p>
  * Use static factory methods on this interface to create a snapshot.

--- a/context-propagation/src/main/java/io/micrometer/context/ContextSnapshot.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ContextSnapshot.java
@@ -25,6 +25,16 @@ import java.util.function.Predicate;
  * methods to propagate those values.
  *
  * <p>
+ * Implementations are disallowed to store {@code null} values. If a
+ * {@link ThreadLocal} is not set, or it's value is {@code null}, there is no way of
+ * distinguishing one from the other. In such a case, the {@link ContextSnapshot}
+ * simply doesn't contain a capture fpr the particular {@link ThreadLocal}. Due to this
+ * limitation, other types of context accessed via {@link ContextAccessor} should not
+ * operate on {@code null} values. Implementations should still make an effort and
+ * prevent storing {@code null} in the snapshot in case a {@link ContextAccessor}
+ * doesn't comply with this requirement.
+ *
+ * <p>
  * Use static factory methods on this interface to create a snapshot.
  *
  * @author Rossen Stoyanchev

--- a/context-propagation/src/main/java/io/micrometer/context/DefaultContextSnapshot.java
+++ b/context-propagation/src/main/java/io/micrometer/context/DefaultContextSnapshot.java
@@ -17,6 +17,7 @@ package io.micrometer.context;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Predicate;
 
 /**
@@ -161,6 +162,9 @@ final class DefaultContextSnapshot extends HashMap<Object, Object> implements Co
             ContextAccessor<?, ?> accessor = contextRegistry.getContextAccessorForRead(context);
             snapshot = (snapshot != null ? snapshot : new DefaultContextSnapshot(contextRegistry));
             ((ContextAccessor<Object, ?>) accessor).readValues(context, keyPredicate, snapshot);
+        }
+        if (snapshot != null) {
+            snapshot.values().removeIf(Objects::isNull);
         }
         return (snapshot != null ? snapshot : emptyContextSnapshot);
     }

--- a/context-propagation/src/main/java/io/micrometer/context/DefaultContextSnapshot.java
+++ b/context-propagation/src/main/java/io/micrometer/context/DefaultContextSnapshot.java
@@ -77,7 +77,9 @@ final class DefaultContextSnapshot extends HashMap<Object, Object> implements Co
         for (ThreadLocalAccessor<?> accessor : this.contextRegistry.getThreadLocalAccessors()) {
             Object key = accessor.key();
             if (keyPredicate.test(key) && this.containsKey(key)) {
-                previousValues = setThreadLocal(key, get(key), accessor, previousValues);
+                Object value = get(key);
+                assert value != null : "snapshot contains disallowed null mapping for key: " + key;
+                previousValues = setThreadLocal(key, value, accessor, previousValues);
             }
         }
         return DefaultScope.from(previousValues, this.contextRegistry);

--- a/context-propagation/src/main/java/io/micrometer/context/ThreadLocalAccessor.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ThreadLocalAccessor.java
@@ -38,13 +38,16 @@ public interface ThreadLocalAccessor<V> {
     Object key();
 
     /**
-     * Return the current {@link ThreadLocal} value, or {@code null} if not set.
+     * Return the current {@link ThreadLocal} value.
      */
     @Nullable
     V getValue();
 
     /**
      * Set the {@link ThreadLocal} value.
+     * <p>
+     * The argument will not be {@code null} when called from {@link ContextSnapshot}
+     * implementations, which are disallowed to store mappings to {@code null}.
      * @param value the value to set
      */
     void setValue(V value);
@@ -56,6 +59,9 @@ public interface ThreadLocalAccessor<V> {
 
     /**
      * Remove the current {@link ThreadLocal} value and set the previously stored one.
+     * <p>
+     * The argument will not be {@code null} when called from {@link ContextSnapshot}
+     * implementations, which are disallowed to store mappings to {@code null}.
      * @param previousValue previous value to set
      * @since 1.0.1
      */

--- a/context-propagation/src/test/java/io/micrometer/context/DefaultContextSnapshotTests.java
+++ b/context-propagation/src/test/java/io/micrometer/context/DefaultContextSnapshotTests.java
@@ -16,6 +16,7 @@
 package io.micrometer.context;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import io.micrometer.context.ContextSnapshot.Scope;
@@ -51,6 +52,25 @@ public class DefaultContextSnapshotTests {
         finally {
             ObservationThreadLocalHolder.reset();
         }
+    }
+
+    @Test
+    void test_null_value_in_source_context() {
+        this.registry.registerContextAccessor(new TestContextAccessor());
+        this.registry.registerThreadLocalAccessor(new ObservationThreadLocalAccessor());
+
+        String key = ObservationThreadLocalAccessor.KEY;
+
+        String emptyValue = ObservationThreadLocalHolder.getValue();
+        Map<String, String> sourceContext = Collections.singletonMap(key, emptyValue);
+
+        ContextSnapshot snapshot =
+            ContextSnapshot.captureAll(this.registry, sourceContext);
+
+        try (Scope scope = snapshot.setThreadLocals()) {
+            assertThat(ObservationThreadLocalHolder.getValue()).isEqualTo(emptyValue);
+        }
+        assertThat(ObservationThreadLocalHolder.getValue()).isEqualTo(emptyValue);
     }
 
     @Test

--- a/context-propagation/src/test/java/io/micrometer/context/DefaultContextSnapshotTests.java
+++ b/context-propagation/src/test/java/io/micrometer/context/DefaultContextSnapshotTests.java
@@ -16,7 +16,6 @@
 package io.micrometer.context;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import io.micrometer.context.ContextSnapshot.Scope;
@@ -64,8 +63,7 @@ public class DefaultContextSnapshotTests {
         String emptyValue = ObservationThreadLocalHolder.getValue();
         Map<String, String> sourceContext = Collections.singletonMap(key, emptyValue);
 
-        ContextSnapshot snapshot =
-            ContextSnapshot.captureAll(this.registry, sourceContext);
+        ContextSnapshot snapshot = ContextSnapshot.captureAll(this.registry, sourceContext);
 
         try (Scope scope = snapshot.setThreadLocals()) {
             assertThat(ObservationThreadLocalHolder.getValue()).isEqualTo(emptyValue);

--- a/context-propagation/src/test/java/io/micrometer/context/DefaultContextSnapshotTests.java
+++ b/context-propagation/src/test/java/io/micrometer/context/DefaultContextSnapshotTests.java
@@ -267,8 +267,7 @@ public class DefaultContextSnapshotTests {
     @SuppressWarnings("unchecked")
     void should_fail_assertion_if_null_value_makes_it_into_snapshot() {
         ThreadLocal<String> fooThreadLocal = new ThreadLocal<>();
-        TestThreadLocalAccessor fooThreadLocalAccessor =
-            new TestThreadLocalAccessor("foo", fooThreadLocal);
+        TestThreadLocalAccessor fooThreadLocalAccessor = new TestThreadLocalAccessor("foo", fooThreadLocal);
         this.registry.registerThreadLocalAccessor(fooThreadLocalAccessor);
 
         fooThreadLocal.set("present");
@@ -280,8 +279,7 @@ public class DefaultContextSnapshotTests {
         // Imitating a broken implementation that let mapping to null into the storage:
         snapshotStorage.put("foo", null);
 
-        assertThatExceptionOfType(AssertionError.class)
-            .isThrownBy(snapshot::setThreadLocals)
+        assertThatExceptionOfType(AssertionError.class).isThrownBy(snapshot::setThreadLocals)
             .withMessage("snapshot contains disallowed null mapping for key: foo");
     }
 

--- a/context-propagation/src/test/java/io/micrometer/context/ObservationThreadLocalAccessor.java
+++ b/context-propagation/src/test/java/io/micrometer/context/ObservationThreadLocalAccessor.java
@@ -54,4 +54,5 @@ public class ObservationThreadLocalAccessor implements ThreadLocalAccessor<Strin
         Objects.requireNonNull(previousValue);
         setValue(previousValue);
     }
+
 }

--- a/context-propagation/src/test/java/io/micrometer/context/ObservationThreadLocalAccessor.java
+++ b/context-propagation/src/test/java/io/micrometer/context/ObservationThreadLocalAccessor.java
@@ -15,6 +15,8 @@
  */
 package io.micrometer.context;
 
+import java.util.Objects;
+
 /**
  * Example {@link ThreadLocalAccessor} implementation.
  */
@@ -34,6 +36,9 @@ public class ObservationThreadLocalAccessor implements ThreadLocalAccessor<Strin
 
     @Override
     public void setValue(String value) {
+        // ThreadLocalAccessor API is @NonNullApi by default
+        // so we don't expect null here
+        Objects.requireNonNull(value);
         ObservationThreadLocalHolder.setValue(value);
     }
 
@@ -42,4 +47,11 @@ public class ObservationThreadLocalAccessor implements ThreadLocalAccessor<Strin
         ObservationThreadLocalHolder.reset();
     }
 
+    @Override
+    public void restore(String previousValue) {
+        // ThreadLocalAccessor API is @NonNullApi by default
+        // so we don't expect null here
+        Objects.requireNonNull(previousValue);
+        setValue(previousValue);
+    }
 }

--- a/context-propagation/src/test/java/io/micrometer/context/ObservationThreadLocalHolder.java
+++ b/context-propagation/src/test/java/io/micrometer/context/ObservationThreadLocalHolder.java
@@ -19,14 +19,11 @@ public class ObservationThreadLocalHolder {
 
     private static final ThreadLocal<String> holder = new ThreadLocal<>();
 
-    public static void resetValue() {
-        holder.remove();
-    }
-
     public static void setValue(String value) {
         holder.set(value);
     }
 
+    @Nullable
     public static String getValue() {
         return holder.get();
     }

--- a/context-propagation/src/test/java/io/micrometer/context/TestThreadLocalAccessor.java
+++ b/context-propagation/src/test/java/io/micrometer/context/TestThreadLocalAccessor.java
@@ -15,6 +15,8 @@
  */
 package io.micrometer.context;
 
+import java.util.Objects;
+
 /**
  * ThreadLocalAccessor for testing purposes with a given key and {@link ThreadLocal}
  * instance.
@@ -46,6 +48,9 @@ class TestThreadLocalAccessor implements ThreadLocalAccessor<String> {
 
     @Override
     public void setValue(String value) {
+        // ThreadLocalAccessor API is @NonNullApi by default
+        // so we don't expect null here
+        Objects.requireNonNull(value);
         this.threadLocal.set(value);
     }
 


### PR DESCRIPTION
This change takes care of guaranteeing `@NonNullApi` package annotation is in effect for `ThreadLocalAccessor` calls when dealing with `ContextSnapshot`. When a source context `Object` provided `null` for a key, the API would not have held its guarantees. Now we explicitly make sure the backing `Map` has no mappings to `null`.