### PR TITLE
Introduce variations of `setValue` that can return a scope to be closed instead of calling `restore`

### DIFF
--- a/context-propagation/src/main/java/io/micrometer/context/DefaultContextSnapshot.java
+++ b/context-propagation/src/main/java/io/micrometer/context/DefaultContextSnapshot.java
@@ -99,7 +99,8 @@ final class DefaultContextSnapshot extends HashMap<Object, Object> implements Co
         ThreadLocalAccessor.Scope scope = ((ThreadLocalAccessor<V>) accessor).setValueScoped(value);
         if (scope == null) {
             previousValues.put(key, previousValue);
-        } else {
+        }
+        else {
             previousValues.put(key, scope);
         }
         return previousValues;
@@ -112,7 +113,8 @@ final class DefaultContextSnapshot extends HashMap<Object, Object> implements Co
         ThreadLocalAccessor.Scope scope = accessor.setValueScoped();
         if (scope == null) {
             previousValues.put(key, previousValue);
-        } else {
+        }
+        else {
             previousValues.put(key, scope);
         }
         return previousValues;

--- a/context-propagation/src/main/java/io/micrometer/context/ThreadLocalAccessor.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ThreadLocalAccessor.java
@@ -16,7 +16,6 @@
 package io.micrometer.context;
 
 import java.io.Closeable;
-import java.io.IOException;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 

--- a/context-propagation/src/main/java/io/micrometer/context/ThreadLocalAccessor.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ThreadLocalAccessor.java
@@ -15,6 +15,8 @@
  */
 package io.micrometer.context;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -67,6 +69,18 @@ public interface ThreadLocalAccessor<V> {
     void setValue(V value);
 
     /**
+     * A variation of {@link #setValue(Object)} that returns {@link Scope} which will be closed {@link Scope#close()} to restore the previous value.
+     * @return A scope of null to behave like {@link #setValue(Object)}
+     *
+     * @since 1.0.4
+     */
+    @Nullable
+    default Scope setValueScoped(V value) {
+        setValue(value);
+        return null;
+    }
+
+    /**
      * Called instead of {@link #setValue(Object)} in order to remove the current
      * {@link ThreadLocal} value at the start of a
      * {@link io.micrometer.context.ContextSnapshot.Scope}.
@@ -75,6 +89,18 @@ public interface ThreadLocalAccessor<V> {
      */
     default void setValue() {
         reset();
+    }
+
+    /**
+     * A variation of {@link #setValue()} that returns {@link Scope} which will be closed {@link Scope#close()} to restore the previous value.
+     * @return A scope of null to behave like {@link #setValue()}
+     *
+     * @since 1.0.4
+     */
+    @Nullable
+    default Scope setValueScoped() {
+        setValue();
+        return null;
     }
 
     /**
@@ -115,4 +141,15 @@ public interface ThreadLocalAccessor<V> {
         setValue();
     }
 
+    /**
+     * The scope that should be closed after the value is restored.
+     *
+     * @author Denis Stepanov
+     * @since 1.0.4
+     */
+    interface Scope extends Closeable {
+
+        @Override
+        void close();
+    }
 }

--- a/context-propagation/src/main/java/io/micrometer/context/ThreadLocalAccessor.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ThreadLocalAccessor.java
@@ -142,7 +142,7 @@ public interface ThreadLocalAccessor<V> {
     }
 
     /**
-     * The scope that should be closed after the value is restored.
+     * The scope that should be closed to restore the previous value.
      *
      * @author Denis Stepanov
      * @since 1.0.4

--- a/context-propagation/src/main/java/io/micrometer/context/ThreadLocalAccessor.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ThreadLocalAccessor.java
@@ -69,7 +69,8 @@ public interface ThreadLocalAccessor<V> {
     void setValue(V value);
 
     /**
-     * A variation of {@link #setValue(Object)} that returns {@link Scope} which will be closed {@link Scope#close()} to restore the previous value.
+     * A variation of {@link #setValue(Object)} that returns {@link Scope} which will be
+     * closed {@link Scope#close()} to restore the previous value.
      * @return A scope of null to behave like {@link #setValue(Object)}
      *
      * @since 1.0.4
@@ -92,7 +93,8 @@ public interface ThreadLocalAccessor<V> {
     }
 
     /**
-     * A variation of {@link #setValue()} that returns {@link Scope} which will be closed {@link Scope#close()} to restore the previous value.
+     * A variation of {@link #setValue()} that returns {@link Scope} which will be closed
+     * {@link Scope#close()} to restore the previous value.
      * @return A scope of null to behave like {@link #setValue()}
      *
      * @since 1.0.4
@@ -151,5 +153,7 @@ public interface ThreadLocalAccessor<V> {
 
         @Override
         void close();
+
     }
+
 }

--- a/context-propagation/src/test/java/io/micrometer/context/DefaultContextSnapshotTests.java
+++ b/context-propagation/src/test/java/io/micrometer/context/DefaultContextSnapshotTests.java
@@ -492,7 +492,8 @@ public class DefaultContextSnapshotTests {
                         .isNull();
                     then(ScopedObservationScopeThreadLocalHolder.getValue()).as("This is the 'null' scope").isNotNull();
                 }
-                then(ScopedObservationScopeThreadLocalHolder.getCurrentObservation()).as("We're back to previous observation")
+                then(ScopedObservationScopeThreadLocalHolder.getCurrentObservation())
+                    .as("We're back to previous observation")
                     .isSameAs(observation);
             }
             then(ScopedObservationScopeThreadLocalHolder.getCurrentObservation())

--- a/context-propagation/src/test/java/io/micrometer/context/StringThreadLocalAccessorScoped.java
+++ b/context-propagation/src/test/java/io/micrometer/context/StringThreadLocalAccessorScoped.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.context;
+
+/**
+ * Example of scoped {@link ThreadLocalAccessor} implementation.
+ */
+public class StringThreadLocalAccessorScoped implements ThreadLocalAccessor<String> {
+
+    public static final String KEY = "string.threadlocal.scoped";
+
+    @Override
+    public Object key() {
+        return KEY;
+    }
+
+    @Override
+    public String getValue() {
+        return StringThreadLocalHolder.getValue();
+    }
+
+    @Override
+    public Scope setValueScoped(String value) {
+        String previousValue = StringThreadLocalHolder.getValue();
+        StringThreadLocalHolder.setValue(value);
+        return () -> StringThreadLocalHolder.setValue(previousValue);
+    }
+
+    @Override
+    public Scope setValueScoped() {
+        String previousValue = StringThreadLocalHolder.getValue();
+        StringThreadLocalHolder.reset();
+        return () -> StringThreadLocalHolder.setValue(previousValue);
+    }
+
+    @Override
+    public void setValue(String value) {
+        throw new IllegalStateException("Not supported");
+    }
+
+}

--- a/context-propagation/src/test/java/io/micrometer/context/observation/ObservationThreadLocalAccessor.java
+++ b/context-propagation/src/test/java/io/micrometer/context/observation/ObservationThreadLocalAccessor.java
@@ -51,13 +51,13 @@ public class ObservationThreadLocalAccessor implements ThreadLocalAccessor<Obser
 
     @Override
     public void restore(Observation value) {
-        Scope scope = ObservationScopeThreadLocalHolder.getValue();
+        io.micrometer.context.observation.Scope scope = ObservationScopeThreadLocalHolder.getValue();
         if (scope == null) {
             String msg = "There is no current scope in thread local. This situation should not happen";
             log.log(Level.WARNING, msg);
             assert false : msg;
         }
-        Scope previousObservationScope = scope.getPreviousObservationScope();
+        io.micrometer.context.observation.Scope previousObservationScope = scope.getPreviousObservationScope();
         if (previousObservationScope == null || value != previousObservationScope.getCurrentObservation()) {
             Observation previousObservation = previousObservationScope != null
                     ? previousObservationScope.getCurrentObservation() : null;
@@ -77,7 +77,7 @@ public class ObservationThreadLocalAccessor implements ThreadLocalAccessor<Obser
     }
 
     private void close() {
-        Scope scope = ObservationScopeThreadLocalHolder.getValue();
+        io.micrometer.context.observation.Scope scope = ObservationScopeThreadLocalHolder.getValue();
         if (scope != null) {
             scope.close();
         }

--- a/context-propagation/src/test/java/io/micrometer/context/observation_scoped/Scope.java
+++ b/context-propagation/src/test/java/io/micrometer/context/observation_scoped/Scope.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.context.observation_scoped;
+
+import java.io.Closeable;
+
+interface Scope extends Closeable {
+
+    ScopedObservation getCurrentObservation();
+
+    Scope getPreviousObservationScope();
+
+    @Override
+    void close();
+
+}

--- a/context-propagation/src/test/java/io/micrometer/context/observation_scoped/ScopedNullObservation.java
+++ b/context-propagation/src/test/java/io/micrometer/context/observation_scoped/ScopedNullObservation.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.context.observation_scoped;
+
+class ScopedNullObservation extends ScopedObservation {
+
+    Scope openScope() {
+        return new ScopedRevertingScope(null);
+    }
+
+}

--- a/context-propagation/src/test/java/io/micrometer/context/observation_scoped/ScopedObservation.java
+++ b/context-propagation/src/test/java/io/micrometer/context/observation_scoped/ScopedObservation.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.context.observation_scoped;
+
+public class ScopedObservation {
+
+    Scope openScope() {
+        return new ScopedRevertingScope(this);
+    }
+
+}

--- a/context-propagation/src/test/java/io/micrometer/context/observation_scoped/ScopedObservationScopeThreadLocalHolder.java
+++ b/context-propagation/src/test/java/io/micrometer/context/observation_scoped/ScopedObservationScopeThreadLocalHolder.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.context.observation_scoped;
+
+public class ScopedObservationScopeThreadLocalHolder {
+
+    private static final ThreadLocal<Scope> holder = new ThreadLocal<>();
+
+    public static void setValue(Scope value) {
+        holder.set(value);
+    }
+
+    public static Scope getValue() {
+        return holder.get();
+    }
+
+    public static ScopedObservation getCurrentObservation() {
+        Scope scope = holder.get();
+        if (scope != null) {
+            return scope.getCurrentObservation();
+        }
+        return null;
+    }
+
+}

--- a/context-propagation/src/test/java/io/micrometer/context/observation_scoped/ScopedObservationThreadLocalAccessor.java
+++ b/context-propagation/src/test/java/io/micrometer/context/observation_scoped/ScopedObservationThreadLocalAccessor.java
@@ -51,5 +51,4 @@ public class ScopedObservationThreadLocalAccessor implements ThreadLocalAccessor
         return scope::close;
     }
 
-
 }

--- a/context-propagation/src/test/java/io/micrometer/context/observation_scoped/ScopedObservationThreadLocalAccessor.java
+++ b/context-propagation/src/test/java/io/micrometer/context/observation_scoped/ScopedObservationThreadLocalAccessor.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.context.observation_scoped;
+
+import io.micrometer.context.ThreadLocalAccessor;
+
+/**
+ * Example {@link ThreadLocalAccessor} implementation.
+ */
+public class ScopedObservationThreadLocalAccessor implements ThreadLocalAccessor<ScopedObservation> {
+
+    public static final String KEY = "micrometer.observation_scoped";
+
+    @Override
+    public Object key() {
+        return KEY;
+    }
+
+    @Override
+    public ScopedObservation getValue() {
+        return ScopedObservationScopeThreadLocalHolder.getCurrentObservation();
+    }
+
+    @Override
+    public void setValue(ScopedObservation value) {
+        throw new IllegalStateException("Not supported");
+    }
+
+    @Override
+    public Scope setValueScoped(ScopedObservation value) {
+        io.micrometer.context.observation_scoped.Scope scope = value.openScope();
+        return scope::close;
+    }
+
+    @Override
+    public Scope setValueScoped() {
+        io.micrometer.context.observation_scoped.Scope scope = new ScopedNullObservation().openScope();
+        return scope::close;
+    }
+
+
+}

--- a/context-propagation/src/test/java/io/micrometer/context/observation_scoped/ScopedRevertingScope.java
+++ b/context-propagation/src/test/java/io/micrometer/context/observation_scoped/ScopedRevertingScope.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.context.observation_scoped;
+
+class ScopedRevertingScope implements Scope {
+
+    private final Scope previousScope;
+
+    private final ScopedObservation observation;
+
+    ScopedRevertingScope(ScopedObservation observation) {
+        this.previousScope = ScopedObservationScopeThreadLocalHolder.getValue();
+        this.observation = observation;
+        ScopedObservationScopeThreadLocalHolder.setValue(this);
+    }
+
+    @Override
+    public void close() {
+        ScopedObservationScopeThreadLocalHolder.setValue(this.previousScope);
+    }
+
+    @Override
+    public Scope getPreviousObservationScope() {
+        return this.previousScope;
+    }
+
+    @Override
+    public ScopedObservation getCurrentObservation() {
+        return this.observation;
+    }
+
+}


### PR DESCRIPTION
This is simplifying and prevents errors when working with contextual objects that provide a callback to restore the previous state. One of the invalid implementations caused https://github.com/reactor/reactor-core/issues/3500

FYI @chemicL @marcingrzejszczak 