### PR TITLE
Reverse order of ThreadLocalAccessors upon scope close

### DIFF
--- a/context-propagation/src/main/java/io/micrometer/context/DefaultContextSnapshot.java
+++ b/context-propagation/src/main/java/io/micrometer/context/DefaultContextSnapshot.java
@@ -16,6 +16,7 @@
 package io.micrometer.context;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 
@@ -74,7 +75,9 @@ final class DefaultContextSnapshot extends HashMap<Object, Object> implements Co
     @Override
     public Scope setThreadLocals(Predicate<Object> keyPredicate) {
         Map<Object, Object> previousValues = null;
-        for (ThreadLocalAccessor<?> accessor : this.contextRegistry.getThreadLocalAccessors()) {
+        List<ThreadLocalAccessor<?>> accessors = this.contextRegistry.getThreadLocalAccessors();
+        for (int i = 0; i < accessors.size(); ++i) {
+            ThreadLocalAccessor<?> accessor = accessors.get(i);
             Object key = accessor.key();
             if (keyPredicate.test(key)) {
                 if (this.containsKey(key)) {
@@ -130,7 +133,9 @@ final class DefaultContextSnapshot extends HashMap<Object, Object> implements Co
 
         @Override
         public void close() {
-            for (ThreadLocalAccessor<?> accessor : this.contextRegistry.getThreadLocalAccessors()) {
+            List<ThreadLocalAccessor<?>> accessors = this.contextRegistry.getThreadLocalAccessors();
+            for (int i = accessors.size() - 1; i >= 0; --i) {
+                ThreadLocalAccessor<?> accessor = accessors.get(i);
                 if (this.previousValues.containsKey(accessor.key())) {
                     Object previousValue = this.previousValues.get(accessor.key());
                     resetThreadLocalValue(accessor, previousValue);

--- a/context-propagation/src/test/java/io/micrometer/context/ScopedValueSnapshotTests.java
+++ b/context-propagation/src/test/java/io/micrometer/context/ScopedValueSnapshotTests.java
@@ -154,4 +154,24 @@ public class ScopedValueSnapshotTests {
         registry.removeContextAccessor(accessor);
     }
 
+    @Test
+    void duplicateThreadLocalAccessorsForSameThreadLocalHaveReverseOrderUponClose() {
+        registry.registerThreadLocalAccessor(new ScopedValueThreadLocalAccessor("other"));
+
+        ScopedValue value = ScopedValue.create("value");
+
+        ContextSnapshot snapshot;
+        try (Scope scope = Scope.open(value)) {
+            snapshot = snapshotFactory.captureAll();
+        }
+
+        try (ContextSnapshot.Scope scope = snapshot.setThreadLocals()) {
+            assertThat(ScopeHolder.currentValue()).isEqualTo(value);
+        }
+
+        assertThat(ScopeHolder.currentValue()).isNull();
+
+        registry.removeThreadLocalAccessor("other");
+    }
+
 }

--- a/context-propagation/src/test/java/io/micrometer/scopedvalue/ScopedValueThreadLocalAccessor.java
+++ b/context-propagation/src/test/java/io/micrometer/scopedvalue/ScopedValueThreadLocalAccessor.java
@@ -29,9 +29,19 @@ public class ScopedValueThreadLocalAccessor implements ThreadLocalAccessor<Scope
      */
     public static final String KEY = "svtla";
 
+    private final String key;
+
+    public ScopedValueThreadLocalAccessor() {
+        this.key = KEY;
+    }
+
+    public ScopedValueThreadLocalAccessor(String key) {
+        this.key = key;
+    }
+
     @Override
     public Object key() {
-        return KEY;
+        return this.key;
     }
 
     @Override


### PR DESCRIPTION
This change processes registered ThreadLocalAccessors in reverse order when a scope is closed.

Resolves #130.