### PR TITLE
Add more intuitive method to wrap ExecutorService 

### DIFF
--- a/context-propagation/src/main/java/io/micrometer/context/ContextExecutorService.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ContextExecutorService.java
@@ -151,6 +151,22 @@ public class ContextExecutorService<EXECUTOR extends ExecutorService> implements
     }
 
     /**
+     * Wrap the given {@code ExecutorService} in order to propagate context to any
+     * executed task through the given {@link ContextSnapshotFactory}.
+     * <p>
+     * This method only captures ThreadLocal value. Use
+     * {@link #wrap(ExecutorService, Supplier)} in order to be able to work with other
+     * contexts.
+     * </p>
+     * @param service the executorService to wrap
+     * @param contextSnapshotFactory {@link ContextSnapshotFactory} for capturing a
+     * {@link ContextSnapshot} at the point when tasks are scheduled
+     */
+    public static ExecutorService wrap(ExecutorService service, ContextSnapshotFactory contextSnapshotFactory) {
+        return new ContextExecutorService<>(service, contextSnapshotFactory::captureAll);
+    }
+
+    /**
      * Variant of {@link #wrap(ExecutorService, Supplier)} that uses
      * {@link ContextSnapshot#captureAll(Object...)} to create the context snapshot.
      * @param service the executorService to wrap

--- a/context-propagation/src/main/java/io/micrometer/context/ContextExecutorService.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ContextExecutorService.java
@@ -142,7 +142,6 @@ public class ContextExecutorService<EXECUTOR extends ExecutorService> implements
     /**
      * Wrap the given {@code ExecutorService} in order to propagate context to any
      * executed task through the given {@link ContextSnapshot} supplier.
-     *
      * <p>
      * Typically, a {@link ContextSnapshotFactory} can be used to supply the snapshot. In
      * the case that only ThreadLocal values are to be captured, the

--- a/context-propagation/src/main/java/io/micrometer/context/ContextExecutorService.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ContextExecutorService.java
@@ -150,6 +150,7 @@ public class ContextExecutorService<EXECUTOR extends ExecutorService> implements
      * @param contextSnapshotFactory {@link ContextSnapshotFactory} for capturing a
      * {@link ContextSnapshot} at the point when tasks are scheduled
      * @return {@code ExecutorService} wrapper
+     * @since 1.1.2
      */
     public static ExecutorService wrap(ExecutorService service, ContextSnapshotFactory contextSnapshotFactory) {
         return new ContextExecutorService<>(service, contextSnapshotFactory::captureAll);

--- a/context-propagation/src/main/java/io/micrometer/context/ContextExecutorService.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ContextExecutorService.java
@@ -142,6 +142,12 @@ public class ContextExecutorService<EXECUTOR extends ExecutorService> implements
     /**
      * Wrap the given {@code ExecutorService} in order to propagate context to any
      * executed task through the given {@link ContextSnapshot} supplier.
+     *
+     * <p>
+     * Typically, a {@link ContextSnapshotFactory} can be used to supply the snapshot. In
+     * the case that only ThreadLocal values are to be captured, the
+     * {@link #wrap(ExecutorService, ContextSnapshotFactory)} variant can be used.
+     * </p>
      * @param service the executorService to wrap
      * @param snapshotSupplier supplier for capturing a {@link ContextSnapshot} at the
      * point when tasks are scheduled

--- a/context-propagation/src/main/java/io/micrometer/context/ContextExecutorService.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ContextExecutorService.java
@@ -143,12 +143,13 @@ public class ContextExecutorService<EXECUTOR extends ExecutorService> implements
      * Wrap the given {@code ExecutorService} in order to propagate context to any
      * executed task through the given {@link ContextSnapshotFactory}.
      * <p>
-     * This method only captures ThreadLocal value. To work with other types of
-     * contexts, use {@link #wrap(ExecutorService, Supplier)}.
+     * This method only captures ThreadLocal value. To work with other types of contexts,
+     * use {@link #wrap(ExecutorService, Supplier)}.
      * </p>
      * @param service the executorService to wrap
      * @param contextSnapshotFactory {@link ContextSnapshotFactory} for capturing a
      * {@link ContextSnapshot} at the point when tasks are scheduled
+     * @return {@code ExecutorService} wrapper
      */
     public static ExecutorService wrap(ExecutorService service, ContextSnapshotFactory contextSnapshotFactory) {
         return new ContextExecutorService<>(service, contextSnapshotFactory::captureAll);
@@ -165,6 +166,7 @@ public class ContextExecutorService<EXECUTOR extends ExecutorService> implements
      * @param service the executorService to wrap
      * @param snapshotSupplier supplier for capturing a {@link ContextSnapshot} at the
      * point when tasks are scheduled
+     * @return {@code ExecutorService} wrapper
      */
     public static ExecutorService wrap(ExecutorService service, Supplier<ContextSnapshot> snapshotSupplier) {
         return new ContextExecutorService<>(service, snapshotSupplier);
@@ -174,6 +176,7 @@ public class ContextExecutorService<EXECUTOR extends ExecutorService> implements
      * Variant of {@link #wrap(ExecutorService, Supplier)} that uses
      * {@link ContextSnapshot#captureAll(Object...)} to create the context snapshot.
      * @param service the executorService to wrap
+     * @return {@code ExecutorService} wrapper
      * @deprecated use {@link #wrap(ExecutorService, Supplier)}
      */
     @Deprecated

--- a/context-propagation/src/main/java/io/micrometer/context/ContextExecutorService.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ContextExecutorService.java
@@ -141,6 +141,21 @@ public class ContextExecutorService<EXECUTOR extends ExecutorService> implements
 
     /**
      * Wrap the given {@code ExecutorService} in order to propagate context to any
+     * executed task through the given {@link ContextSnapshotFactory}.
+     * <p>
+     * This method only captures ThreadLocal value. To work with other types of
+     * contexts, use {@link #wrap(ExecutorService, Supplier)}.
+     * </p>
+     * @param service the executorService to wrap
+     * @param contextSnapshotFactory {@link ContextSnapshotFactory} for capturing a
+     * {@link ContextSnapshot} at the point when tasks are scheduled
+     */
+    public static ExecutorService wrap(ExecutorService service, ContextSnapshotFactory contextSnapshotFactory) {
+        return new ContextExecutorService<>(service, contextSnapshotFactory::captureAll);
+    }
+
+    /**
+     * Wrap the given {@code ExecutorService} in order to propagate context to any
      * executed task through the given {@link ContextSnapshot} supplier.
      * <p>
      * Typically, a {@link ContextSnapshotFactory} can be used to supply the snapshot. In
@@ -153,22 +168,6 @@ public class ContextExecutorService<EXECUTOR extends ExecutorService> implements
      */
     public static ExecutorService wrap(ExecutorService service, Supplier<ContextSnapshot> snapshotSupplier) {
         return new ContextExecutorService<>(service, snapshotSupplier);
-    }
-
-    /**
-     * Wrap the given {@code ExecutorService} in order to propagate context to any
-     * executed task through the given {@link ContextSnapshotFactory}.
-     * <p>
-     * This method only captures ThreadLocal value. Use
-     * {@link #wrap(ExecutorService, Supplier)} in order to be able to work with other
-     * contexts.
-     * </p>
-     * @param service the executorService to wrap
-     * @param contextSnapshotFactory {@link ContextSnapshotFactory} for capturing a
-     * {@link ContextSnapshot} at the point when tasks are scheduled
-     */
-    public static ExecutorService wrap(ExecutorService service, ContextSnapshotFactory contextSnapshotFactory) {
-        return new ContextExecutorService<>(service, contextSnapshotFactory::captureAll);
     }
 
     /**

--- a/context-propagation/src/main/java/io/micrometer/context/ContextScheduledExecutorService.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ContextScheduledExecutorService.java
@@ -66,10 +66,34 @@ public final class ContextScheduledExecutorService extends ContextExecutorServic
 
     /**
      * Wrap the given {@code ScheduledExecutorService} in order to propagate context to
+     * any executed task through the given {@link ContextSnapshotFactory}.
+     * <p>
+     * This method only captures ThreadLocal value. To work with other types of contexts,
+     * use {@link #wrap(ScheduledExecutorService, Supplier)}.
+     * </p>
+     * @param service the executorService to wrap
+     * @param contextSnapshotFactory {@link ContextSnapshotFactory} for capturing a
+     * {@link ContextSnapshot} at the point when tasks are scheduled
+     * @return {@code ScheduledExecutorService} wrapper
+     */
+    public static ScheduledExecutorService wrap(ScheduledExecutorService service,
+            ContextSnapshotFactory contextSnapshotFactory) {
+        return new ContextScheduledExecutorService(service, contextSnapshotFactory::captureAll);
+    }
+
+    /**
+     * Wrap the given {@code ScheduledExecutorService} in order to propagate context to
      * any executed task through the given {@link ContextSnapshot} supplier.
+     * <p>
+     * Typically, a {@link ContextSnapshotFactory} can be used to supply the snapshot. In
+     * the case that only ThreadLocal values are to be captured, the
+     * {@link #wrap(ScheduledExecutorService, ContextSnapshotFactory)} variant can be
+     * used.
+     * </p>
      * @param service the executorService to wrap
      * @param supplier supplier for capturing a {@link ContextSnapshot} at the point when
      * tasks are scheduled
+     * @return {@code ScheduledExecutorService} wrapper
      */
     public static ScheduledExecutorService wrap(ScheduledExecutorService service, Supplier<ContextSnapshot> supplier) {
         return new ContextScheduledExecutorService(service, supplier);
@@ -79,6 +103,7 @@ public final class ContextScheduledExecutorService extends ContextExecutorServic
      * Variant of {@link #wrap(ScheduledExecutorService, Supplier)} that uses
      * {@link ContextSnapshot#captureAll(Object...)} to create the context snapshot.
      * @param service the executorService to wrap
+     * @return {@code ScheduledExecutorService} wrapper
      * @deprecated use {@link #wrap(ScheduledExecutorService, Supplier)}
      */
     @Deprecated

--- a/context-propagation/src/main/java/io/micrometer/context/ContextScheduledExecutorService.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ContextScheduledExecutorService.java
@@ -75,6 +75,7 @@ public final class ContextScheduledExecutorService extends ContextExecutorServic
      * @param contextSnapshotFactory {@link ContextSnapshotFactory} for capturing a
      * {@link ContextSnapshot} at the point when tasks are scheduled
      * @return {@code ScheduledExecutorService} wrapper
+     * @since 1.1.2
      */
     public static ScheduledExecutorService wrap(ScheduledExecutorService service,
             ContextSnapshotFactory contextSnapshotFactory) {

--- a/context-propagation/src/test/java/io/micrometer/context/ContextWrappingTests.java
+++ b/context-propagation/src/test/java/io/micrometer/context/ContextWrappingTests.java
@@ -163,6 +163,15 @@ class ContextWrappingTests {
                     atomic -> then(atomic.get())
                         .as("With context container the thread local information should be propagated")
                         .isEqualTo("hello from map"));
+
+            StringThreadLocalHolder.setValue("hello at time of creation of the executor");
+            runInNewThread(
+                    ContextScheduledExecutorService
+                        .wrap(executorService, () -> defaultSnapshotFactory.captureAll(sourceContext)),
+                    valueInNewThread,
+                    atomic -> then(atomic.get())
+                        .as("With context container the thread local information should be propagated")
+                        .isEqualTo("hello from map"));
         }
         finally {
             executorService.shutdown();


### PR DESCRIPTION
The `ContextExecutorService#wrap` method accepting a `Supplier<ContextSnapshot>` can be a mystery for users as it's not immediately obvious that a `ContextSnapshotFactory` needs to be used to supply a `ContextSnapshot`. This change adds an overload that accepts the `ContextSnapshotFactory` explicitly and only works with ThreadLocal values as a sane default. For more advanced use cases the variant accepting `Supplier` can be used.

Related to #295 