### PR TITLE
Fix Slf4jThreadLocalAccessor with keys for missing values

### DIFF
--- a/context-propagation/src/main/java/io/micrometer/context/integration/Slf4jThreadLocalAccessor.java
+++ b/context-propagation/src/main/java/io/micrometer/context/integration/Slf4jThreadLocalAccessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 the original author or authors.
+ * Copyright 2024-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,6 +126,9 @@ public class Slf4jThreadLocalAccessor implements ThreadLocalAccessor<Map<String,
                 String mdcValue = value.get(key);
                 if (mdcValue != null) {
                     MDC.put(key, mdcValue);
+                }
+                else {
+                    MDC.remove(key);
                 }
             }
         }


### PR DESCRIPTION
In case of missing MDC entries, when a scope was closed, the value should be removed. This was not the case and that could lead to leaks of these MDC entries. This change takes the missing previous values into account and clears them from the MDC in case they were set by a snapshot.

Fixes #347.