### PR TITLE
fix: Allow to remove a ThreadLocalAccessor by Key of Type Object

### DIFF
--- a/context-propagation/src/main/java/io/micrometer/context/ContextRegistry.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ContextRegistry.java
@@ -151,7 +151,7 @@ public class ContextRegistry {
      * @param key under which the accessor got registered
      * @return {@code true} when accessor got successfully removed
      */
-    public boolean removeThreadLocalAccessor(String key) {
+    public boolean removeThreadLocalAccessor(Object key) {
         for (ThreadLocalAccessor<?> existing : this.threadLocalAccessors) {
             if (existing.key().equals(key)) {
                 return this.threadLocalAccessors.remove(existing);


### PR DESCRIPTION
The `ThreadLocalAccessor.key()` is of Type Object. Thus, when it comes to delete a predefined `ThreadLocalAccessor` which have a non-String key, it's becomes impossible to delete. This behavior was observed while attempting to remove `org.springframework.security.core.context.ReactiveSecurityContextHolderThreadLocalAccessor` from the `ContextRegistry`, which have a key of type `java.lang.Class`.

This change will just switch the method parameter in order to support the Type `java.lang.Object` as key, which shouldn't be a breaking change, even in a minor version.