### PR TITLE
Add method to remove ThreadLocalAccessor by Object key

### DIFF
--- a/context-propagation/src/main/java/io/micrometer/context/ContextRegistry.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ContextRegistry.java
@@ -151,6 +151,16 @@ public class ContextRegistry {
      * @return {@code true} when accessor got successfully removed
      */
     public boolean removeThreadLocalAccessor(String key) {
+        return removeThreadLocalAccessor((Object) key);
+    }
+
+    /**
+     * Removes a {@link ThreadLocalAccessor}.
+     * @param key under which the accessor got registered
+     * @return {@code true} when accessor got successfully removed
+     * @since 1.1.4
+     */
+    public boolean removeThreadLocalAccessor(Object key) {
         for (ThreadLocalAccessor<?> existing : this.threadLocalAccessors) {
             if (existing.key().equals(key)) {
                 return this.threadLocalAccessors.remove(existing);

--- a/context-propagation/src/test/java/io/micrometer/context/ContextRegistryTests.java
+++ b/context-propagation/src/test/java/io/micrometer/context/ContextRegistryTests.java
@@ -133,13 +133,17 @@ class ContextRegistryTests {
 
     @Test
     void should_remove_a_thread_local_accessor_with_a_given_key() {
+        Object baz = new Object();
         TestThreadLocalAccessor accessor1 = new TestThreadLocalAccessor("foo", new ThreadLocal<>());
         TestThreadLocalAccessor accessor2 = new TestThreadLocalAccessor("bar", new ThreadLocal<>());
+        TestThreadLocalAccessor accessor3 = new TestThreadLocalAccessor(baz, new ThreadLocal<>());
         this.registry.registerThreadLocalAccessor(accessor1);
         this.registry.registerThreadLocalAccessor(accessor2);
-        assertThat(this.registry.getThreadLocalAccessors()).containsExactly(accessor1, accessor2);
+        this.registry.registerThreadLocalAccessor(accessor3);
+        assertThat(this.registry.getThreadLocalAccessors()).containsExactly(accessor1, accessor2, accessor3);
 
         assertThat(this.registry.removeThreadLocalAccessor("foo")).isTrue();
+        assertThat(this.registry.removeThreadLocalAccessor(baz)).isTrue();
 
         assertThat(this.registry.getThreadLocalAccessors()).containsExactly(accessor2);
     }

--- a/context-propagation/src/test/java/io/micrometer/context/TestThreadLocalAccessor.java
+++ b/context-propagation/src/test/java/io/micrometer/context/TestThreadLocalAccessor.java
@@ -25,12 +25,12 @@ import java.util.Objects;
  */
 class TestThreadLocalAccessor implements ThreadLocalAccessor<String> {
 
-    private final String key;
+    private final Object key;
 
     // Normally this wouldn't be a field in the accessor but ok for testing purposes
     private final ThreadLocal<String> threadLocal;
 
-    TestThreadLocalAccessor(String key, ThreadLocal<String> threadLocal) {
+    TestThreadLocalAccessor(Object key, ThreadLocal<String> threadLocal) {
         this.key = key;
         this.threadLocal = threadLocal;
     }


### PR DESCRIPTION
`ThreadLocalAccessor` exposes its key as an Object, and an accessor can be registered as an instance, so that makes it possible to register, but removing is only possible by String key. 

This change adds an overloaded `removeThreadLocalAcccessor` with an Object key.

Closes gh-119