### PR TITLE
Introduce ContextThreadFactory

### DIFF
--- a/context-propagation/src/main/java/io/micrometer/context/ContextThreadFactory.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ContextThreadFactory.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.context;
+
+import java.util.Objects;
+import java.util.concurrent.ThreadFactory;
+import java.util.function.Supplier;
+
+/**
+ * Wraps a {@link ThreadFactory} in order to capture context via {@link ContextSnapshot}
+ * when a new thread is created, and propagate context to the thread when it is executed.
+ * <p>
+ * Intended to be used with short-lived threads dedicated to a single task, rather than
+ * threads in a thread pool to which multiple tasks are delegated. Typically, the wrapped
+ * {@link ThreadFactory} should create Virtual Threads.
+ * </p>
+ *
+ * @author Phil Clay
+ * @since 1.2.2
+ */
+public class ContextThreadFactory implements ThreadFactory {
+
+    /**
+     * The {@link ThreadFactory} to which to delegate {@link Thread} creation.
+     */
+    private final ThreadFactory threadFactory;
+
+    /**
+     * Supplies a {@link ContextSnapshot} to be propagated to the spawned threads.
+     */
+    private final Supplier<ContextSnapshot> contextSnapshotSupplier;
+
+    private ContextThreadFactory(ThreadFactory threadFactory, Supplier<ContextSnapshot> contextSnapshotSupplier) {
+        this.threadFactory = Objects.requireNonNull(threadFactory, "threadFactory must not be null");
+        this.contextSnapshotSupplier = Objects.requireNonNull(contextSnapshotSupplier,
+                "contextSnapshotSupplier must not be null");
+    }
+
+    @Override
+    public Thread newThread(Runnable runnable) {
+        return threadFactory.newThread(capture().wrap(runnable));
+    }
+
+    private ContextSnapshot capture() {
+        return this.contextSnapshotSupplier.get();
+    }
+
+    /**
+     * Wrap the given {@code ThreadFactory} in order to propagate context to any executed
+     * runnable through the given {@link ContextSnapshotFactory}.
+     * <p>
+     * This method only captures ThreadLocal value. To work with other types of contexts,
+     * use {@link #wrap(ThreadFactory, Supplier)}.
+     * </p>
+     * @param factory the threadFactory to wrap
+     * @param contextSnapshotFactory {@link ContextSnapshotFactory} for capturing a
+     * {@link ContextSnapshot} at the point when a new Thread is created from a Runnable
+     * @return {@code ThreadFactory} wrapper
+     */
+    public static ThreadFactory wrap(ThreadFactory factory, ContextSnapshotFactory contextSnapshotFactory) {
+        return wrap(factory, contextSnapshotFactory::captureAll);
+    }
+
+    /**
+     * Wrap the given {@code ThreadFactory} in order to propagate context to any executed
+     * runnable through the given {@link ContextSnapshot} supplier.
+     * <p>
+     * Typically, a {@link ContextSnapshotFactory} can be used to supply the snapshot. In
+     * the case that only ThreadLocal values are to be captured, the
+     * {@link #wrap(ThreadFactory, ContextSnapshotFactory)} variant can be used.
+     * </p>
+     * @param service the threadFactory to wrap
+     * @param contextSnapshotSupplier supplier for capturing a {@link ContextSnapshot} at
+     * the point when a new Thread is created from a Runnable
+     * @return {@code ThreadFactory} wrapper
+     */
+    public static ThreadFactory wrap(ThreadFactory service, Supplier<ContextSnapshot> contextSnapshotSupplier) {
+        return new ContextThreadFactory(service, contextSnapshotSupplier);
+    }
+
+}

--- a/context-propagation/src/test/java/io/micrometer/context/ContextThreadFactoryTests.java
+++ b/context-propagation/src/test/java/io/micrometer/context/ContextThreadFactoryTests.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.context;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link ContextThreadFactory}.
+ */
+class ContextThreadFactoryTests {
+
+    private final ContextRegistry registry = new ContextRegistry()
+        .registerThreadLocalAccessor(new StringThreadLocalAccessor());
+
+    private final ContextSnapshotFactory snapshotFactory = ContextSnapshotFactory.builder()
+        .contextRegistry(registry)
+        .clearMissing(false)
+        .build();
+
+    @AfterEach
+    void clear() {
+        StringThreadLocalHolder.reset();
+    }
+
+    @Test
+    void should_propagate_context_to_new_thread_using_snapshot_factory() throws InterruptedException {
+        StringThreadLocalHolder.setValue("hello");
+        AtomicReference<@Nullable String> valueInNewThread = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        ThreadFactory factory = ContextThreadFactory.wrap(Executors.defaultThreadFactory(), snapshotFactory);
+        Thread thread = factory.newThread(() -> {
+            valueInNewThread.set(StringThreadLocalHolder.getValue());
+            latch.countDown();
+        });
+        thread.start();
+        awaitAndJoin(thread, latch);
+
+        assertThat(valueInNewThread.get()).isEqualTo("hello");
+    }
+
+    @Test
+    void should_propagate_context_to_new_thread_using_snapshot_supplier() throws InterruptedException {
+        StringThreadLocalHolder.setValue("world");
+        AtomicReference<@Nullable String> valueInNewThread = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        ThreadFactory factory = ContextThreadFactory.wrap(Executors.defaultThreadFactory(),
+                snapshotFactory::captureAll);
+        Thread thread = factory.newThread(() -> {
+            valueInNewThread.set(StringThreadLocalHolder.getValue());
+            latch.countDown();
+        });
+        thread.start();
+        awaitAndJoin(thread, latch);
+
+        assertThat(valueInNewThread.get()).isEqualTo("world");
+    }
+
+    @Test
+    void should_capture_context_at_thread_creation_time_not_at_execution_time() throws InterruptedException {
+        StringThreadLocalHolder.setValue("captured-value");
+        AtomicReference<@Nullable String> valueInNewThread = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        ThreadFactory factory = ContextThreadFactory.wrap(Executors.defaultThreadFactory(), snapshotFactory);
+        // Create the thread while context is set
+        Thread thread = factory.newThread(() -> {
+            valueInNewThread.set(StringThreadLocalHolder.getValue());
+            latch.countDown();
+        });
+
+        // Change context after thread creation
+        StringThreadLocalHolder.setValue("changed-value");
+
+        thread.start();
+        awaitAndJoin(thread, latch);
+
+        assertThat(valueInNewThread.get()).as("Context should be captured at thread creation time, not execution time")
+            .isEqualTo("captured-value");
+    }
+
+    @Test
+    void should_delegate_thread_creation_to_wrapped_factory() {
+        AtomicReference<@Nullable Thread> createdThread = new AtomicReference<>();
+        ThreadFactory delegateFactory = r -> {
+            Thread t = new Thread(r, "custom-thread-name");
+            createdThread.set(t);
+            return t;
+        };
+
+        ThreadFactory factory = ContextThreadFactory.wrap(delegateFactory, snapshotFactory);
+        Thread thread = factory.newThread(() -> {
+        });
+
+        assertThat(thread).isSameAs(createdThread.get());
+        assertThat(thread.getName()).isEqualTo("custom-thread-name");
+    }
+
+    @Test
+    void should_use_thread_created_by_delegate_factory() throws Exception {
+        StringThreadLocalHolder.setValue("delegate-value");
+        AtomicReference<@Nullable String> valueInNewThread = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        ThreadFactory delegateFactory = r -> new Thread(r, "delegate-thread");
+        ThreadFactory factory = ContextThreadFactory.wrap(delegateFactory, snapshotFactory);
+        Thread thread = factory.newThread(() -> {
+            valueInNewThread.set(StringThreadLocalHolder.getValue());
+            latch.countDown();
+        });
+        thread.start();
+        awaitAndJoin(thread, latch);
+
+        assertThat(thread.getName()).isEqualTo("delegate-thread");
+        assertThat(valueInNewThread.get()).isEqualTo("delegate-value");
+    }
+
+    @Test
+    @SuppressWarnings("NullAway")
+    void should_throw_on_null_thread_factory() {
+        assertThatThrownBy(() -> ContextThreadFactory.wrap(null, snapshotFactory))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("threadFactory must not be null");
+    }
+
+    @Test
+    @SuppressWarnings("NullAway")
+    void should_throw_on_null_snapshot_factory() {
+        assertThatThrownBy(
+                () -> ContextThreadFactory.wrap(Executors.defaultThreadFactory(), (ContextSnapshotFactory) null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @SuppressWarnings("NullAway")
+    void should_throw_on_null_snapshot_supplier() {
+        assertThatThrownBy(
+                () -> ContextThreadFactory.wrap(Executors.defaultThreadFactory(), (Supplier<ContextSnapshot>) null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("contextSnapshotSupplier must not be null");
+    }
+
+    private void awaitAndJoin(Thread thread, CountDownLatch latch) throws InterruptedException {
+        assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+        thread.join(TimeUnit.SECONDS.toMillis(5));
+    }
+
+}


### PR DESCRIPTION
Introduce `ContextThreadFactory` to propagate context to new Threads created by a delegate `ThreadFactory`.

The new `ContextThreadFactory` class was loosely modeled after the existing [`ContextExecutorService`](https://github.com/micrometer-metrics/context-propagation/blob/9fe5a974e48e1ed6f3c0fa7bf3191a724955fb3a/context-propagation/src/main/java/io/micrometer/context/ContextExecutorService.java) class. They serve essentially the same purpose, but `ContextThreadFactory` wraps a `ThreadFactory` instead of an `ExecutorService`.

See [this related comment](https://github.com/micrometer-metrics/context-propagation/issues/419#issuecomment-4290161098)

Example usage with [Java 25's Structured Concurrency](https://docs.oracle.com/en/java/javase/25/core/structured-concurrency.html) preview:

```java
public class RobotAssemblyService {

    // Wrap a ThreadFactory with a ContextThreadFactory that propagates context
    private final ThreadFactory threadFactory = ContextThreadFactory.wrap(
            Thread.ofVirtual().name("robot-assembly-", 0).factory(),
            ContextSnapshotFactory.builder().build());

    public Robot assemble() throws InterruptedException {
        try (var scope = StructuredTaskScope.open(
                awaitAllSuccessfulOrThrow(),
                configuration -> configuration
                        .withName("robot-assemble")
                        .withTimeout(Duration.ofSeconds(2))
                        // use the ContextThreadFactory
                        .withThreadFactory(threadFactory))) {

            Subtask<Arm> armTask = scope.fork(this::assembleArm);
            Subtask<Leg> legTask = scope.fork(this::assembleLeg);

            scope.join();

            Arm arm = armTask.get();
            Leg leg = legTask.get();
            return new Robot(arm, leg);
        } catch (FailedException e) {
            throw new RobotAssemblyException(e.getCause());
        } catch (TimeoutException e) {
            throw new RobotAssemblyException(e);
        }
    }

    // ...
}
```