### PR TITLE
Remove Gradle Wrapper configuration block

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -335,8 +335,4 @@ nexusPublishing {
 	}
 }
 
-wrapper {
-	gradleVersion = '9.2.1'
-}
-
 defaultTasks 'build'


### PR DESCRIPTION
This PR removes the Gradle Wrapper configuration block as it's not used by Dependabot.

See https://github.com/micrometer-metrics/context-propagation/pull/542