### PR TITLE
Allow ordering ThreadLocalAccessor registrations

### DIFF
--- a/context-propagation/src/main/java/io/micrometer/context/ContextRegistry.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ContextRegistry.java
@@ -131,18 +131,30 @@ public class ContextRegistry {
 
     /**
      * Register a {@link ThreadLocalAccessor}. If there is an existing registration with
-     * the same {@link ThreadLocalAccessor#key() key}, it is removed first.
+     * the same {@link ThreadLocalAccessor#key() key}, it is removed first. Accessors are
+     * registered in ascending {@link ThreadLocalAccessor#getOrder() order}, preserving
+     * registration order for accessors with the same order.
      * @param accessor the accessor to register
      * @return the same registry instance
      */
     public ContextRegistry registerThreadLocalAccessor(ThreadLocalAccessor<?> accessor) {
-        for (ThreadLocalAccessor<?> existing : this.threadLocalAccessors) {
-            if (existing.key().equals(accessor.key())) {
-                this.threadLocalAccessors.remove(existing);
-                break;
+        synchronized (this.threadLocalAccessors) {
+            for (ThreadLocalAccessor<?> existing : this.threadLocalAccessors) {
+                if (existing.key().equals(accessor.key())) {
+                    this.threadLocalAccessors.remove(existing);
+                    break;
+                }
             }
+            int index = 0;
+            int order = accessor.getOrder();
+            for (ThreadLocalAccessor<?> existing : this.threadLocalAccessors) {
+                if (existing.getOrder() > order) {
+                    break;
+                }
+                index++;
+            }
+            this.threadLocalAccessors.add(index, accessor);
         }
-        this.threadLocalAccessors.add(accessor);
         return this;
     }
 
@@ -162,12 +174,14 @@ public class ContextRegistry {
      * @since 1.1.4
      */
     public boolean removeThreadLocalAccessor(Object key) {
-        for (ThreadLocalAccessor<?> existing : this.threadLocalAccessors) {
-            if (existing.key().equals(key)) {
-                return this.threadLocalAccessors.remove(existing);
+        synchronized (this.threadLocalAccessors) {
+            for (ThreadLocalAccessor<?> existing : this.threadLocalAccessors) {
+                if (existing.key().equals(key)) {
+                    return this.threadLocalAccessors.remove(existing);
+                }
             }
+            return false;
         }
-        return false;
     }
 
     /**

--- a/context-propagation/src/main/java/io/micrometer/context/DefaultContextSnapshot.java
+++ b/context-propagation/src/main/java/io/micrometer/context/DefaultContextSnapshot.java
@@ -18,7 +18,6 @@ package io.micrometer.context;
 import org.jspecify.annotations.Nullable;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 
@@ -77,9 +76,9 @@ final class DefaultContextSnapshot extends HashMap<Object, Object> implements Co
     @Override
     public Scope setThreadLocals(Predicate<Object> keyPredicate) {
         Map<Object, Object> previousValues = null;
-        List<ThreadLocalAccessor<?>> accessors = this.contextRegistry.getThreadLocalAccessors();
-        for (int i = 0; i < accessors.size(); ++i) {
-            ThreadLocalAccessor<?> accessor = accessors.get(i);
+        ThreadLocalAccessor<?>[] accessors = this.contextRegistry.getThreadLocalAccessors()
+            .toArray(new ThreadLocalAccessor<?>[0]);
+        for (ThreadLocalAccessor<?> accessor : accessors) {
             Object key = accessor.key();
             if (keyPredicate.test(key)) {
                 if (this.containsKey(key)) {
@@ -92,7 +91,7 @@ final class DefaultContextSnapshot extends HashMap<Object, Object> implements Co
                 }
             }
         }
-        return DefaultScope.from(previousValues, this.contextRegistry);
+        return DefaultScope.from(previousValues, accessors);
     }
 
     @SuppressWarnings("unchecked")
@@ -126,18 +125,17 @@ final class DefaultContextSnapshot extends HashMap<Object, Object> implements Co
 
         private final Map<Object, Object> previousValues;
 
-        private final ContextRegistry contextRegistry;
+        private final ThreadLocalAccessor<?>[] accessors;
 
-        private DefaultScope(Map<Object, Object> previousValues, ContextRegistry contextRegistry) {
+        private DefaultScope(Map<Object, Object> previousValues, ThreadLocalAccessor<?>[] accessors) {
             this.previousValues = previousValues;
-            this.contextRegistry = contextRegistry;
+            this.accessors = accessors;
         }
 
         @Override
         public void close() {
-            List<ThreadLocalAccessor<?>> accessors = this.contextRegistry.getThreadLocalAccessors();
-            for (int i = accessors.size() - 1; i >= 0; --i) {
-                ThreadLocalAccessor<?> accessor = accessors.get(i);
+            for (int i = this.accessors.length - 1; i >= 0; --i) {
+                ThreadLocalAccessor<?> accessor = this.accessors[i];
                 if (this.previousValues.containsKey(accessor.key())) {
                     Object previousValue = this.previousValues.get(accessor.key());
                     resetThreadLocalValue(accessor, previousValue);
@@ -155,8 +153,8 @@ final class DefaultContextSnapshot extends HashMap<Object, Object> implements Co
             }
         }
 
-        public static Scope from(@Nullable Map<Object, Object> previousValues, ContextRegistry registry) {
-            return (previousValues != null ? new DefaultScope(previousValues, registry) : () -> {
+        public static Scope from(@Nullable Map<Object, Object> previousValues, ThreadLocalAccessor<?>[] accessors) {
+            return (previousValues != null ? new DefaultScope(previousValues, accessors) : () -> {
             });
         }
 

--- a/context-propagation/src/main/java/io/micrometer/context/DefaultContextSnapshotFactory.java
+++ b/context-propagation/src/main/java/io/micrometer/context/DefaultContextSnapshotFactory.java
@@ -17,7 +17,6 @@ package io.micrometer.context;
 
 import org.jspecify.annotations.Nullable;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Predicate;
@@ -119,7 +118,9 @@ final class DefaultContextSnapshotFactory implements ContextSnapshotFactory {
             boolean clearMissing) {
         ContextAccessor<?, ?> contextAccessor = contextRegistry.getContextAccessorForRead(sourceContext);
         Map<Object, Object> previousValues = null;
-        for (ThreadLocalAccessor<?> threadLocalAccessor : contextRegistry.getThreadLocalAccessors()) {
+        ThreadLocalAccessor<?>[] accessors = contextRegistry.getThreadLocalAccessors()
+            .toArray(new ThreadLocalAccessor<?>[0]);
+        for (ThreadLocalAccessor<?> threadLocalAccessor : accessors) {
             Object key = threadLocalAccessor.key();
             Object value = ((ContextAccessor<C, ?>) contextAccessor).readValue((C) sourceContext, key);
             if (value != null) {
@@ -129,7 +130,7 @@ final class DefaultContextSnapshotFactory implements ContextSnapshotFactory {
                 previousValues = DefaultContextSnapshot.clearThreadLocal(key, threadLocalAccessor, previousValues);
             }
         }
-        return DefaultContextSnapshot.DefaultScope.from(previousValues, contextRegistry);
+        return DefaultContextSnapshot.DefaultScope.from(previousValues, accessors);
     }
 
     @SuppressWarnings("unchecked")
@@ -140,7 +141,8 @@ final class DefaultContextSnapshotFactory implements ContextSnapshotFactory {
         }
         ContextAccessor<?, ?> contextAccessor = contextRegistry.getContextAccessorForRead(sourceContext);
         Map<Object, Object> previousValues = null;
-        List<ThreadLocalAccessor<?>> accessors = contextRegistry.getThreadLocalAccessors();
+        ThreadLocalAccessor<?>[] accessors = contextRegistry.getThreadLocalAccessors()
+            .toArray(new ThreadLocalAccessor<?>[0]);
         for (String key : keys) {
             Object value = ((ContextAccessor<C, ?>) contextAccessor).readValue((C) sourceContext, key);
             if (value != null) {
@@ -162,7 +164,7 @@ final class DefaultContextSnapshotFactory implements ContextSnapshotFactory {
                 }
             }
         }
-        return DefaultContextSnapshot.DefaultScope.from(previousValues, contextRegistry);
+        return DefaultContextSnapshot.DefaultScope.from(previousValues, accessors);
     }
 
     static final class Builder implements ContextSnapshotFactory.Builder {

--- a/context-propagation/src/main/java/io/micrometer/context/ThreadLocalAccessor.java
+++ b/context-propagation/src/main/java/io/micrometer/context/ThreadLocalAccessor.java
@@ -39,6 +39,26 @@ public interface ThreadLocalAccessor<V> {
     Object key();
 
     /**
+     * Return the order of this accessor in a {@link ContextRegistry}. Accessors with a
+     * lower order come first. Accessors with the same order retain their registration
+     * order. The default is {@code 0}.
+     * <p>
+     * Snapshots apply accessors in registry order and restore them in reverse order.
+     * Explicit keys passed to
+     * {@link ContextSnapshotFactory#setThreadLocalsFrom(Object, String...)} continue to
+     * determine the order in which values are set.
+     * <p>
+     * For example, an accessor that depends on another accessor with the default order
+     * can return {@code 1} to be applied after it. The order must remain unchanged while
+     * the accessor is registered.
+     * @return the order of this accessor
+     * @since 1.3.0
+     */
+    default int getOrder() {
+        return 0;
+    }
+
+    /**
      * Return the current {@link ThreadLocal} value.
      * <p>
      * This method is called in two scenarios:

--- a/context-propagation/src/test/java/io/micrometer/context/ContextSnapshotRegistryMutationTests.java
+++ b/context-propagation/src/test/java/io/micrometer/context/ContextSnapshotRegistryMutationTests.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.context;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ContextSnapshotRegistryMutationTests {
+
+    @ParameterizedTest
+    @EnumSource(ScopeSource.class)
+    void should_not_apply_an_accessor_twice_when_registration_changes_during_setup(ScopeSource source) {
+        ContextRegistry registry = new ContextRegistry().registerContextAccessor(new TestContextAccessor());
+        ThreadLocal<String> firstValue = new ThreadLocal<>();
+        firstValue.set("previous");
+        AtomicBoolean registered = new AtomicBoolean();
+        TestThreadLocalAccessor first = new TestThreadLocalAccessor("first", firstValue) {
+            @Override
+            public void setValue(String value) {
+                super.setValue(value);
+                if (registered.compareAndSet(false, true)) {
+                    registry.registerThreadLocalAccessor(earlierAccessor());
+                }
+            }
+        };
+        registry.registerThreadLocalAccessor(first);
+        Map<String, String> values = new HashMap<>();
+        values.put("first", "captured");
+
+        try (ContextSnapshot.Scope scope = source.open(registry, values)) {
+            assertThat(firstValue.get()).isEqualTo("captured");
+        }
+
+        assertThat(firstValue.get()).isEqualTo("previous");
+    }
+
+    @ParameterizedTest
+    @EnumSource(ScopeSource.class)
+    void should_not_skip_restoration_when_registration_changes_during_close(ScopeSource source) {
+        ContextRegistry registry = new ContextRegistry().registerContextAccessor(new TestContextAccessor());
+        ThreadLocal<String> firstValue = new ThreadLocal<>();
+        ThreadLocal<String> secondValue = new ThreadLocal<>();
+        firstValue.set("previous");
+        secondValue.set("previous");
+        registry.registerThreadLocalAccessor(new TestThreadLocalAccessor("first", firstValue));
+        registry.registerThreadLocalAccessor(new TestThreadLocalAccessor("second", secondValue) {
+            @Override
+            public void restore(String previousValue) {
+                super.restore(previousValue);
+                registry.registerThreadLocalAccessor(earlierAccessor());
+            }
+        });
+        Map<String, String> values = new HashMap<>();
+        values.put("first", "captured");
+        values.put("second", "captured");
+
+        try (ContextSnapshot.Scope scope = source.open(registry, values)) {
+            assertThat(firstValue.get()).isEqualTo("captured");
+            assertThat(secondValue.get()).isEqualTo("captured");
+        }
+
+        assertThat(firstValue.get()).isEqualTo("previous");
+        assertThat(secondValue.get()).isEqualTo("previous");
+    }
+
+    @ParameterizedTest
+    @EnumSource(ScopeSource.class)
+    void should_restore_original_accessor_when_it_is_replaced_during_scope(ScopeSource source) {
+        ContextRegistry registry = new ContextRegistry().registerContextAccessor(new TestContextAccessor());
+        ThreadLocal<String> originalValue = new ThreadLocal<>();
+        ThreadLocal<String> replacementValue = new ThreadLocal<>();
+        originalValue.set("original");
+        replacementValue.set("replacement");
+        registry.registerThreadLocalAccessor(new TestThreadLocalAccessor("first", originalValue));
+        Map<String, String> values = new HashMap<>();
+        values.put("first", "captured");
+
+        try (ContextSnapshot.Scope scope = source.open(registry, values)) {
+            registry.removeThreadLocalAccessor("first");
+            registry.registerThreadLocalAccessor(new TestThreadLocalAccessor("first", replacementValue));
+        }
+
+        assertThat(originalValue.get()).isEqualTo("original");
+        assertThat(replacementValue.get()).isEqualTo("replacement");
+    }
+
+    private static ThreadLocalAccessor<String> earlierAccessor() {
+        return new TestThreadLocalAccessor("added", new ThreadLocal<>()) {
+            @Override
+            public int getOrder() {
+                return -1;
+            }
+        };
+    }
+
+    enum ScopeSource {
+
+        SNAPSHOT {
+            @Override
+            ContextSnapshot.Scope open(ContextRegistry registry, Map<String, String> values) {
+                DefaultContextSnapshot snapshot = new DefaultContextSnapshot(registry, false);
+                snapshot.putAll(values);
+                return snapshot.setThreadLocals();
+            }
+        },
+
+        CONTEXT {
+            @Override
+            ContextSnapshot.Scope open(ContextRegistry registry, Map<String, String> values) {
+                return ContextSnapshotFactory.builder().contextRegistry(registry).build().setThreadLocalsFrom(values);
+            }
+        },
+
+        EXPLICIT_KEYS {
+            @Override
+            ContextSnapshot.Scope open(ContextRegistry registry, Map<String, String> values) {
+                return ContextSnapshotFactory.builder()
+                    .contextRegistry(registry)
+                    .build()
+                    .setThreadLocalsFrom(values, "first", "second");
+            }
+        };
+
+        abstract ContextSnapshot.Scope open(ContextRegistry registry, Map<String, String> values);
+
+    }
+
+}

--- a/context-propagation/src/test/java/io/micrometer/context/ThreadLocalAccessorOrderingTests.java
+++ b/context-propagation/src/test/java/io/micrometer/context/ThreadLocalAccessorOrderingTests.java
@@ -1,0 +1,318 @@
+/**
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.context;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ThreadLocalAccessorOrderingTests {
+
+    @Test
+    void should_set_dependencies_first_and_restore_them_last() {
+        List<String> events = new ArrayList<>();
+        RecordingAccessor first = new RecordingAccessor("first", 0, events);
+        RecordingAccessor second = new RecordingAccessor("second", 1, events) {
+            @Override
+            public void setValue(String value) {
+                assertThat(first.getValue()).isEqualTo(value);
+                super.setValue(value);
+            }
+        };
+        ContextRegistry registry = new ContextRegistry().registerThreadLocalAccessor(second)
+            .registerThreadLocalAccessor(first);
+        DefaultContextSnapshot snapshot = new DefaultContextSnapshot(registry, false);
+        snapshot.put("first", "captured");
+        snapshot.put("second", "captured");
+
+        try (ContextSnapshot.Scope scope = snapshot.setThreadLocals()) {
+            assertThat(second.getValue()).isEqualTo("captured");
+        }
+
+        assertThat(events).containsExactly("set:first", "set:second", "restore:second", "restore:first");
+        assertThat(first.getValue()).isNull();
+        assertThat(second.getValue()).isNull();
+    }
+
+    @Test
+    void should_preserve_registration_order_for_equal_and_default_orders() {
+        ContextRegistry registry = new ContextRegistry();
+        TestThreadLocalAccessor defaultOrder = new TestThreadLocalAccessor("default", new ThreadLocal<>());
+        RecordingAccessor first = accessor("first", 0);
+        RecordingAccessor second = accessor("second", 0);
+        RecordingAccessor lowest = accessor("lowest", Integer.MIN_VALUE);
+        RecordingAccessor highest = accessor("highest", Integer.MAX_VALUE);
+
+        registry.registerThreadLocalAccessor(first)
+            .registerThreadLocalAccessor(highest)
+            .registerThreadLocalAccessor(defaultOrder)
+            .registerThreadLocalAccessor(lowest)
+            .registerThreadLocalAccessor(second);
+
+        assertThat(registry.getThreadLocalAccessors()).containsExactly(lowest, first, defaultOrder, second, highest);
+    }
+
+    @Test
+    void should_order_replacements_and_reregistered_accessors() {
+        ContextRegistry registry = new ContextRegistry();
+        RecordingAccessor first = accessor("first", 0);
+        RecordingAccessor second = accessor("second", 1);
+        RecordingAccessor replacement = accessor("second", -1);
+        registry.registerThreadLocalAccessor(second).registerThreadLocalAccessor(first);
+        registry.registerThreadLocalAccessor(replacement);
+        assertThat(registry.getThreadLocalAccessors()).containsExactly(replacement, first);
+
+        assertThat(registry.removeThreadLocalAccessor("second")).isTrue();
+        registry.registerThreadLocalAccessor(second);
+        assertThat(registry.getThreadLocalAccessors()).containsExactly(first, second);
+
+        registry.registerThreadLocalAccessor(accessor("third", 0)).registerThreadLocalAccessor(first);
+        assertThat(registry.getThreadLocalAccessors()).extracting(ThreadLocalAccessor::key)
+            .containsExactly("third", "first", "second");
+    }
+
+    @Test
+    void should_restore_nested_scopes_in_reverse_order() {
+        List<String> events = new ArrayList<>();
+        RecordingAccessor first = new RecordingAccessor("first", 0, events);
+        RecordingAccessor second = new RecordingAccessor("second", 1, events);
+        ContextRegistry registry = new ContextRegistry().registerThreadLocalAccessor(second)
+            .registerThreadLocalAccessor(first);
+        DefaultContextSnapshot outer = new DefaultContextSnapshot(registry, false);
+        outer.put("first", "outer");
+        outer.put("second", "outer");
+        DefaultContextSnapshot inner = new DefaultContextSnapshot(registry, false);
+        inner.put("first", "inner");
+        inner.put("second", "inner");
+
+        try (ContextSnapshot.Scope scope = outer.setThreadLocals()) {
+            try (ContextSnapshot.Scope nestedScope = inner.setThreadLocals()) {
+                assertThat(first.getValue()).isEqualTo("inner");
+                assertThat(second.getValue()).isEqualTo("inner");
+            }
+            assertThat(first.getValue()).isEqualTo("outer");
+            assertThat(second.getValue()).isEqualTo("outer");
+        }
+
+        assertThat(events).containsExactly("set:first", "set:second", "set:first", "set:second", "restore:second",
+                "restore:first", "restore:second", "restore:first");
+        assertThat(first.getValue()).isNull();
+        assertThat(second.getValue()).isNull();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void should_preserve_order_when_values_are_missing(boolean clearMissing) {
+        List<String> events = new ArrayList<>();
+        RecordingAccessor first = new RecordingAccessor("first", 0, events);
+        RecordingAccessor second = new RecordingAccessor("second", 1, events);
+        ContextRegistry registry = new ContextRegistry().registerThreadLocalAccessor(second)
+            .registerThreadLocalAccessor(first);
+        first.setValue("previous");
+        second.setValue("previous");
+        events.clear();
+        DefaultContextSnapshot snapshot = new DefaultContextSnapshot(registry, clearMissing);
+        snapshot.put("second", "captured");
+
+        try (ContextSnapshot.Scope scope = snapshot.setThreadLocals()) {
+            assertThat(first.getValue()).isEqualTo(clearMissing ? null : "previous");
+            assertThat(second.getValue()).isEqualTo("captured");
+        }
+
+        assertThat(first.getValue()).isEqualTo("previous");
+        assertThat(second.getValue()).isEqualTo("previous");
+        if (clearMissing) {
+            assertThat(events).containsExactly("clear:first", "set:second", "restore:second", "restore:first");
+        }
+        else {
+            assertThat(events).containsExactly("set:second", "restore:second");
+        }
+    }
+
+    @Test
+    void should_order_service_loaded_accessors(@TempDir Path directory) throws Exception {
+        Path services = directory.resolve("META-INF/services/" + ThreadLocalAccessor.class.getName());
+        Files.createDirectories(services.getParent());
+        Files.write(services, Arrays.asList(SecondAccessor.class.getName(), FirstAccessor.class.getName()),
+                StandardCharsets.UTF_8);
+        ContextRegistry registry = new ContextRegistry();
+        ClassLoader previous = Thread.currentThread().getContextClassLoader();
+        try (URLClassLoader loader = new URLClassLoader(new URL[] { directory.toUri().toURL() }, previous)) {
+            Thread.currentThread().setContextClassLoader(loader);
+            registry.loadThreadLocalAccessors();
+            assertThat(registry.getThreadLocalAccessors()).extracting(ThreadLocalAccessor::key)
+                .containsExactly("first", "second");
+        }
+        finally {
+            Thread.currentThread().setContextClassLoader(previous);
+        }
+    }
+
+    @Test
+    void should_apply_registry_order_when_setting_all_values_from_a_context() {
+        List<String> events = new ArrayList<>();
+        RecordingAccessor first = new RecordingAccessor("first", 0, events);
+        RecordingAccessor second = new RecordingAccessor("second", 1, events);
+        ContextRegistry registry = new ContextRegistry().registerThreadLocalAccessor(second)
+            .registerThreadLocalAccessor(first)
+            .registerContextAccessor(new TestContextAccessor());
+        ContextSnapshotFactory factory = ContextSnapshotFactory.builder().contextRegistry(registry).build();
+        Map<String, String> context = new HashMap<>();
+        context.put("first", "captured");
+        context.put("second", "captured");
+
+        try (ContextSnapshot.Scope scope = factory.setThreadLocalsFrom(context)) {
+            assertThat(first.getValue()).isEqualTo("captured");
+            assertThat(second.getValue()).isEqualTo("captured");
+        }
+
+        assertThat(events).containsExactly("set:first", "set:second", "restore:second", "restore:first");
+    }
+
+    @Test
+    void should_preserve_explicit_key_order_when_setting_values_from_a_context() {
+        List<String> events = new ArrayList<>();
+        RecordingAccessor first = new RecordingAccessor("first", 0, events);
+        RecordingAccessor second = new RecordingAccessor("second", 1, events);
+        ContextRegistry registry = new ContextRegistry().registerThreadLocalAccessor(second)
+            .registerThreadLocalAccessor(first)
+            .registerContextAccessor(new TestContextAccessor());
+        ContextSnapshotFactory factory = ContextSnapshotFactory.builder().contextRegistry(registry).build();
+        Map<String, String> context = new HashMap<>();
+        context.put("first", "captured");
+        context.put("second", "captured");
+
+        try (ContextSnapshot.Scope scope = factory.setThreadLocalsFrom(context, "second", "first")) {
+            assertThat(first.getValue()).isEqualTo("captured");
+            assertThat(second.getValue()).isEqualTo("captured");
+        }
+
+        assertThat(events).containsExactly("set:second", "set:first", "restore:second", "restore:first");
+    }
+
+    @Test
+    void should_preserve_order_during_concurrent_registration() throws Exception {
+        ContextRegistry registry = new ContextRegistry();
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            List<Future<?>> registrations = new ArrayList<>();
+            for (int thread = 0; thread < 2; thread++) {
+                int group = thread;
+                registrations.add(executor.submit(() -> {
+                    start.await();
+                    for (int i = 50; i >= 0; i--) {
+                        registry.registerThreadLocalAccessor(accessor(group + ":" + i, i));
+                    }
+                    return null;
+                }));
+            }
+            start.countDown();
+            for (Future<?> registration : registrations) {
+                registration.get(10, TimeUnit.SECONDS);
+            }
+            assertThat(registry.getThreadLocalAccessors()).hasSize(102);
+            assertThat(registry.getThreadLocalAccessors()).extracting(ThreadLocalAccessor::getOrder).isSorted();
+        }
+        finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static RecordingAccessor accessor(String key, int order) {
+        return new RecordingAccessor(key, order, new ArrayList<>());
+    }
+
+    public static class FirstAccessor extends RecordingAccessor {
+
+        public FirstAccessor() {
+            super("first", 0, Collections.emptyList());
+        }
+
+    }
+
+    public static class SecondAccessor extends RecordingAccessor {
+
+        public SecondAccessor() {
+            super("second", 1, Collections.emptyList());
+        }
+
+    }
+
+    private static class RecordingAccessor extends TestThreadLocalAccessor {
+
+        private final int order;
+
+        private final List<String> events;
+
+        RecordingAccessor(String key, int order, List<String> events) {
+            super(key, new ThreadLocal<>());
+            this.order = order;
+            this.events = events;
+        }
+
+        @Override
+        public int getOrder() {
+            return this.order;
+        }
+
+        @Override
+        public void setValue(String value) {
+            this.events.add("set:" + key());
+            super.setValue(value);
+        }
+
+        @Override
+        public void setValue() {
+            this.events.add("clear:" + key());
+            super.setValue();
+        }
+
+        @Override
+        public void restore(String previousValue) {
+            this.events.add("restore:" + key());
+            super.setValue(previousValue);
+        }
+
+        @Override
+        public void restore() {
+            this.events.add("restore:" + key());
+            super.setValue();
+        }
+
+    }
+
+}

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -28,3 +28,14 @@ The following example shows one way to store and restore thread local values by 
 -----
 include::{include-java}/context/DefaultContextSnapshotTests.java[tags=simple,indent=0]
 -----
+
+== Ordering `ThreadLocalAccessor` Implementations
+
+When an accessor depends on another accessor's thread local value, override `ThreadLocalAccessor.getOrder()` to control their order in `ContextRegistry`.
+Snapshots apply accessors with lower order values first and restore them last when a scope closes.
+The default order is `0`; accessors with equal order values retain their registration order.
+For example, an accessor that depends on another accessor with the default order can return `1`.
+This also applies to accessors discovered through `ServiceLoader`.
+When explicit keys are passed to `ContextSnapshotFactory.setThreadLocalsFrom(context, keys...)`, their order continues to determine the order in which values are set.
+The order must remain unchanged while an accessor is registered.
+A scope retains the accessor instances and ordering used when it was opened, so later registry changes do not affect its restoration.


### PR DESCRIPTION
Thread-local accessors can depend on values established by other accessors, but ContextRegistry currently applies them in registration order. This can invoke a dependent accessor before its prerequisite, including when accessors are discovered through ServiceLoader.

Add ThreadLocalAccessor.getOrder() with a default of 0 and register accessors in stable ascending order. Existing accessors retain their registration order, while ordered accessors are restored in reverse registry order. Explicit keys supplied to ContextSnapshotFactory.setThreadLocalsFrom continue to determine setup order.

Scopes retain their original accessor instances and ordering so registry changes during setup or restoration cannot duplicate setup, skip restoration, or restore a value through a replacement accessor.

Tests cover dependent accessors, equal/default orders, replacement and removal, nested scopes, missing values, ServiceLoader, direct context setup, concurrent registration, and registry changes during active scopes.

Validation: ./gradlew check :context-propagation:javadoc --no-build-cache --rerun-tasks --no-scan passes with 82 tests.

Closes #120.